### PR TITLE
docs(ufs): document s3.list_objects_version parameter for S3 mounts

### DIFF
--- a/docs/3-User-Manuals/1-Key-Features/01-ufs.md
+++ b/docs/3-User-Manuals/1-Key-Features/01-ufs.md
@@ -121,6 +121,7 @@ Required parameters for beginners:
 - `s3.credentials.access` / `s3.credentials.secret`: access key and secret of the storage service.
 - `s3.region_name`: region of the storage service. Use `cn` if there is no special requirement.
 - `s3.force.path.style`: addressing mode passed to the S3 client. `true` (default) uses path-style (`http://endpoint/bucket/key`), which is what AWS S3, MinIO, Ceph RGW, localstack and most on-prem gateways expect. Set to `false` for buckets that only accept virtual-host-style addressing (e.g. Volcengine TOS, Alibaba Cloud OSS over the S3 API), where the bucket is encoded as a hostname prefix (`http://bucket.endpoint/key`).
+- `s3.list_objects_version`: which S3 ListObjects API version to use when listing a bucket. `v2` (default) uses ListObjects V2. Set to `v1` for buckets that are incompatible with V2 listing — notably Baidu BOS, which returns `IsTruncated=true` without a `NextContinuationToken` and makes the V2 lister loop forever, so the mount appears to hang. V1 listing uses the last object key as the pagination marker and works around such non-compliant services.
 
 :::note
 For `s3://...` mounts, the CLI can auto-fill `s3.bucket_name` from the URI. For `hdfs://...` mounts, it can infer `hdfs.namenode` and `hdfs.root` from the URI. When Kerberos keys are present without `hdfs.kerberos.ccache` or `KRB5CCNAME`, the CLI prints a warning.


### PR DESCRIPTION
Document the new `s3.list_objects_version` mount parameter in the UFS user manual, alongside the existing S3 parameters.

`v2` (default) uses ListObjects V2. Set to `v1` for buckets that are **incompatible with V2 listing** — notably **Baidu BOS**, which returns `IsTruncated=true` without a `NextContinuationToken`, making the V2 lister loop forever so the mount appears to hang. V1 listing uses the last object key as the marker and works around such services.

Documents the option added in CurvineIO/curvine#936. Follows the same location/style as #66 (`s3.force.path.style`).