### PR TITLE
docs(deploy): rewrite Kubernetes Helm deployment guide

### DIFF
--- a/docs/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/01-k8s-Deployment.md
+++ b/docs/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/01-k8s-Deployment.md
@@ -2,650 +2,158 @@
 sidebar_position: 0
 ---
 
-# k8s Deployment
-This chapter introduces how to deploy Curvine distributed storage cluster on Kubernetes using production-grade Helm Chart.
+# Kubernetes Deployment
+
+Chart: `curvine/curvine`, version `0.3.2-alpha`.
 
 ## Prerequisites
 
-* Kubernetes 1.20+
-* Helm 3.0+
-* PV provisioner (if using PVC storage)
+- Kubernetes 1.20+
+- Helm 3.x
+- A default `StorageClass` for master/worker PVCs
 
-## Quick Start
+## Architecture
 
-### 1. Load Images into Kubernetes Cluster
+Helm release `curvine` is deployed in namespace `curvine`:
 
-Refer to [docker compile](../1-Preparation/02-compile.md#docker-compilation) to build images and import them into the Kubernetes cluster.
+| Resource | Description |
+|----------|-------------|
+| StatefulSet `curvine-master` | Metadata and Raft journal |
+| StatefulSet `curvine-worker` | Data nodes |
+| Service `curvine-master` | Headless, RPC 8995 |
+| Service `curvine-worker` | Headless, RPC 8997 |
 
-### 2. Add Helm Repository (Optional)
+`openKruise.enabled` defaults to `false`. StatefulSets use `apps/v1`.
+
+## Deployment
+
+### Add repository
 
 ```bash
-# If Chart is published to repository
 helm repo add curvine https://curvineio.github.io/helm-charts
 helm repo update
 ```
 
-### 3. Install Chart
-
-#### Option A: Install from Helm Repository (Recommended)
-
->**Note**: The current Helm version provided is based on the main branch and is intended for pre-release use only. To install, you must specify the --devel flag
+### Install
 
 ```bash
-# Install with default configuration
-helm install curvine curvine/curvine -n curvine --create-namespace --devel
-
-# Install with custom replica count
-helm install curvine curvine/curvine -n curvine --create-namespace --devel \
-  --set master.replicas=5 \
-  --set worker.replicas=10
-
-# Install with custom values file
-helm install curvine curvine/curvine -n curvine --create-namespace --devel \
-  -f https://curvineio.github.io/helm/charts/examples/values-prod.yaml
+helm upgrade --install curvine curvine/curvine \
+  --version 0.3.2-alpha \
+  -n curvine \
+  --create-namespace \
+  --wait --timeout 10m
 ```
 
-#### Option B: Install from Local Chart
-
->**Note**: Run these commands from the `helm-charts` directory (parent directory of `curvine-runtime` folder)
+### Verify
 
 ```bash
-# Install with default configuration
-helm install curvine ./curvine-runtime -n curvine --create-namespace
-
-# Install with custom replica count
-helm install curvine ./curvine-runtime -n curvine --create-namespace \
-  --set master.replicas=5 \
-  --set worker.replicas=10
-
-# Install with custom values file
-helm install curvine ./curvine-runtime -n curvine --create-namespace \
-  -f ./curvine-runtime/examples/values-prod.yaml
+kubectl get pods,svc,pvc -n curvine
 ```
 
-### 4. Verify Deployment
+Web UI:
 
 ```bash
-# Check Pod status
-kubectl get pods -n curvine
-
-# View Services
-kubectl get svc -n curvine
-
-# View PersistentVolumeClaims
-kubectl get pvc -n curvine
-
-# Run Helm tests
-helm test curvine -n curvine
-```
-
-### 5. Access Cluster
-
-```bash
-# Port forward to access Master Web UI
 kubectl port-forward -n curvine svc/curvine-master 9000:9000
-
-# Access http://localhost:9000
 ```
 
-## Configuration
+### Master addresses
 
-### View Current Configuration
+Single replica:
 
-```bash
-# View all current values
-helm get values curvine -n curvine
-
-# View specific version values in YAML format
-helm get values curvine -n curvine -o yaml
-
-# View rendered manifests
-helm get manifest curvine -n curvine
-
-# View Chart's values.yaml
-cat ./curvine-runtime/values.yaml
-
-# View specific parameters
-helm get values curvine -n curvine | grep master.replicas
+```text
+curvine-master.curvine.svc.cluster.local:8995
 ```
 
-### Common Parameter Usage Examples
+Three replicas:
 
-#### Adjust Resource Limits
-
-```bash
-# Increase Master resources for high-load scenarios
-helm install curvine ./curvine-runtime -n curvine --create-namespace \
-  --set master.resources.requests.cpu=2000m \
-  --set master.resources.requests.memory=4Gi \
-  --set master.resources.limits.cpu=4000m \
-  --set master.resources.limits.memory=8Gi
-```
-
-#### Configure Node Affinity
-
-```bash
-# Run Master on specific nodes
-helm install curvine ./curvine-runtime -n curvine --create-namespace \
-  --set 'master.nodeSelector.node-type=master' \
-  --set 'worker.nodeSelector.node-type=worker'
-```
-
-#### Enable Worker Privileged Mode
-
-```bash
-# Enabled by default, but can be disabled if needed
-helm install curvine ./curvine-runtime -n curvine --create-namespace \
-  --set worker.privileged=false
-```
-
-#### Configure Multiple Data Directories for Worker
-
-```bash
-# Create values-multi-data.yaml with the following content:
-# worker:
-#   storage:
-#     dataDirs:
-#       - name: "data1"
-#         type: "SSD"
-#         enabled: true
-#         size: "100Gi"
-#         storageClass: "fast-ssd"
-#         mountPath: "/data/data1"
-#       - name: "data2"
-#         type: "HDD"
-#         enabled: true
-#         size: "500Gi"
-#         storageClass: "slow-hdd"
-#         mountPath: "/data/data2"
-
-helm install curvine ./curvine-runtime -n curvine --create-namespace \
-  -f values-multi-data.yaml
-```
-
-#### Adjust Log Level
-
-```bash
-# Set log level to DEBUG for troubleshooting
-helm install curvine ./curvine-runtime -n curvine --create-namespace \
-  --set config.log.level=DEBUG
-```
-
-#### Configure External Master Service
-
-```bash
-# Expose Master Service via LoadBalancer
-helm install curvine ./curvine-runtime -n curvine --create-namespace \
-  --set service.masterExternal.enabled=true \
-  --set service.masterExternal.type=LoadBalancer
-```
-
-### Configuration Parameters
-
-#### Global Parameters
-
-|Parameter|Description|Default Value|
-|:----|:----|:----|
-|global.clusterDomain|Kubernetes cluster domain|cluster.local|
-
-#### Cluster Parameters
-
-|Parameter|Description|Default Value|
-|:----|:----|:----|
-|cluster.id|Cluster identifier|curvine|
-|cluster.formatMaster|Format Master data on startup|false|
-|cluster.formatWorker|Format Worker data on startup|false|
-|cluster.formatJournal|Format journal data on startup|false|
-
-#### Image Configuration
-
-|Parameter|Description|Default Value|
-|:----|:----|:----|
-|image.repository|Container image repository|docker.io/curvine|
-|image.tag|Container image tag|latest|
-|image.pullPolicy|Image pull policy|IfNotPresent|
-|image.pullSecrets|Image pull secrets|[]|
-
-#### Master Configuration
-
-|Parameter|Description|Default Value|
-|:----|:----|:----|
-|master.replicas|Master replica count (must be odd: 1, 3, 5, 7...)|3|
-|master.rpcPort|RPC port|8995|
-|master.journalPort|Journal/Raft port|8996|
-|master.webPort|Web UI port|9000|
-|master.web1Port|Additional Web port|9001|
-|master.storage.meta.enabled|Enable metadata storage|true|
-|master.storage.meta.storageClass|Metadata storage class|"" (default)|
-|master.storage.meta.size|Metadata storage size|10Gi|
-|master.storage.meta.hostPath|Metadata host path (used when no storageClass)|""|
-|master.storage.meta.mountPath|Metadata mount path|/opt/curvine/data/meta|
-|master.storage.journal.enabled|Enable journal storage|true|
-|master.storage.journal.storageClass|Journal storage class|"" (default)|
-|master.storage.journal.size|Journal storage size|50Gi|
-|master.storage.journal.hostPath|Journal host path (used when no storageClass)|""|
-|master.storage.journal.mountPath|Journal mount path|/opt/curvine/data/journal|
-|master.resources.requests.cpu|CPU request|1000m|
-|master.resources.requests.memory|Memory request|2Gi|
-|master.resources.limits.cpu|CPU limit|2000m|
-|master.resources.limits.memory|Memory limit|4Gi|
-|master.nodeSelector|Node selector labels|{}|
-|master.tolerations|Pod tolerations|[]|
-|master.affinity|Pod affinity rules|{}|
-|master.labels|Additional labels|{}|
-|master.annotations|Additional annotations|{}|
-|master.extraEnv|Additional environment variables|[]|
-|master.extraVolumes|Additional volumes|[]|
-|master.extraVolumeMounts|Additional volume mounts|[]|
-
-#### Worker Configuration
-
-|Parameter|Description|Default Value|
-|:----|:----|:----|
-|worker.replicas|Worker replica count|3|
-|worker.rpcPort|RPC port|8997|
-|worker.webPort|Web UI port|9001|
-|worker.hostNetwork|Use host network|false|
-|worker.dnsPolicy|DNS policy|ClusterFirst|
-|worker.privileged|Privileged mode (required for FUSE)|true|
-|worker.storage.dataDirs[0].name|Data directory name|data1|
-|worker.storage.dataDirs[0].type|Storage type (SSD/HDD)|SSD|
-|worker.storage.dataDirs[0].enabled|Enable data directory|true|
-|worker.storage.dataDirs[0].size|Data directory size|10Gi|
-|worker.storage.dataDirs[0].storageClass|Storage class|"" (default)|
-|worker.storage.dataDirs[0].hostPath|Host path (used when no storageClass)|""|
-|worker.storage.dataDirs[0].mountPath|Mount path|/data/data1|
-|worker.resources.requests.cpu|CPU request|2000m|
-|worker.resources.requests.memory|Memory request|4Gi|
-|worker.resources.limits.cpu|CPU limit|4000m|
-|worker.resources.limits.memory|Memory limit|8Gi|
-|worker.nodeSelector|Node selector labels|{}|
-|worker.tolerations|Pod tolerations|[]|
-|worker.antiAffinity.enabled|Enable Pod anti-affinity|true|
-|worker.antiAffinity.type|Anti-affinity type (required/preferred)|preferred|
-|worker.labels|Additional labels|{}|
-|worker.annotations|Additional annotations|{}|
-|worker.extraEnv|Additional environment variables|[]|
-|worker.extraVolumes|Additional volumes|[]|
-|worker.extraVolumeMounts|Additional volume mounts|[]|
-
-#### Service Configuration
-
-|Parameter|Description|Default Value|
-|:----|:----|:----|
-|service.master.type|Master Service type|ClusterIP|
-|service.master.annotations|Master Service annotations|{}|
-|service.masterExternal.enabled|Enable external Master Service|false|
-|service.masterExternal.type|External Service type|ClusterIP|
-|service.masterExternal.annotations|External Service annotations|{}|
-|service.masterExternal.nodePort|NodePort configuration|{}|
-|service.masterExternal.loadBalancerIP|LoadBalancer IP|""|
-|service.masterExternal.loadBalancerSourceRanges|LoadBalancer source ranges|[]|
-
-#### Service Account & RBAC
-
-|Parameter|Description|Default Value|
-|:----|:----|:----|
-|serviceAccount.create|Create Service Account|true|
-|serviceAccount.name|Service Account name|"" (auto-generated)|
-|serviceAccount.annotations|Service Account annotations|{}|
-|rbac.create|Create RBAC resources|true|
-
-#### Curvine Configuration
-
-|Parameter|Description|Default Value|
-|:----|:----|:----|
-|config.master.metaDir|Master metadata directory|/opt/curvine/data/meta|
-|config.journal.enable|Enable journal|true|
-|config.journal.journalDir|Journal directory|/opt/curvine/data/journal|
-|config.client.blockSizeStr|Client block size|64MB|
-|config.log.level|Log level (INFO/DEBUG/WARN/ERROR)|INFO|
-|config.log.logDir|Log directory|/opt/curvine/logs|
-|configOverrides.master|Master configuration override|{}|
-|configOverrides.journal|Journal configuration override|{}|
-|configOverrides.worker|Worker configuration override|{}|
-|configOverrides.client|Client configuration override|{}|
-|configOverrides.log|Log configuration override|{}|
-
-For the complete parameter list, please refer to `values.yaml`.
-
-## Configuration Examples
-
-### Development Environment (Minimal)
-
-```bash
-# Install from Helm repository
-helm install curvine curvine/curvine -n curvine --create-namespace --devel \
-  --set master.replicas=1 \
-  --set worker.replicas=1
-
-# Install from local Chart (run in helm-charts directory)
-helm install curvine ./curvine-runtime -n curvine --create-namespace \
-  -f ./curvine-runtime/examples/values-dev.yaml
-```
-
-### Production Environment (High Availability)
-
-```bash
-# Install from Helm repository
-helm install curvine curvine/curvine -n curvine --create-namespace --devel \
-  --set master.replicas=5 \
-  --set worker.replicas=10 \
-  --set master.storage.meta.storageClass=fast-ssd \
-  --set master.storage.journal.storageClass=fast-ssd
-
-# Install from local Chart (run in helm-charts directory)
-helm install curvine ./curvine-runtime -n curvine --create-namespace \
-  -f ./curvine-runtime/examples/values-prod.yaml
-```
-
-### Bare Metal Environment (Using hostPath)
-
-```bash
-# Install from local Chart (run in helm-charts directory)
-helm install curvine ./curvine-runtime -n curvine --create-namespace \
-  -f ./curvine-runtime/examples/values-baremetal.yaml
-```
-
-### Custom Configuration
-
-```bash
-# Install from Helm repository
-helm install curvine curvine/curvine -n curvine --create-namespace --devel \
-  --set master.replicas=5 \
-  --set worker.replicas=10 \
-  --set master.storage.meta.storageClass=fast-ssd \
-  --set worker.storage.dataDirs[0].storageClass=fast-ssd \
-  --set worker.storage.dataDirs[0].size=500Gi
-
-# Install from local Chart (run in helm-charts directory)
-helm install curvine ./curvine-runtime -n curvine --create-namespace \
-  --set master.replicas=5 \
-  --set worker.replicas=10 \
-  --set master.storage.meta.storageClass=fast-ssd \
-  --set worker.storage.dataDirs[0].storageClass=fast-ssd \
-  --set worker.storage.dataDirs[0].size=500Gi
-```
-
-
-## Storage Configuration
-
-### Using PVC (Recommended for Cloud Environments)
-
-```yaml
-master:
-  storage:
-    meta:
-      storageClass: "fast-ssd"
-      size: "20Gi"
-    journal:
-      storageClass: "fast-ssd"
-      size: "100Gi"
-
-worker:
-  storage:
-    dataDirs:
-      - name: "data1"
-        type: "SSD"
-        enabled: true
-        size: "100Gi"
-        storageClass: "fast-ssd"
-        mountPath: "/data/data1"
-```
-
-### Using hostPath (Recommended for Bare Metal)
-
-```yaml
-master:
-  storage:
-    meta:
-      storageClass: ""
-      hostPath: "/mnt/curvine/master/meta"
-    journal:
-      storageClass: ""
-      hostPath: "/mnt/curvine/master/journal"
-
-worker:
-  storage:
-    dataDirs:
-      - name: "data1"
-        type: "SSD"
-        enabled: true
-        size: "100Gi"
-        storageClass: ""
-        hostPath: "/mnt/nvme0n1/curvine"
-        mountPath: "/data/data1"
-```
-
-### Using emptyDir (For Testing)
-
-```yaml
-master:
-  storage:
-    meta:
-      storageClass: ""
-      hostPath: ""
-    journal:
-      storageClass: ""
-      hostPath: ""
-
-worker:
-  storage:
-    dataDirs:
-      - name: "data1"
-        storageClass: ""
-        hostPath: ""
-```
-
-### Storage Configuration Examples
-
-#### Quick Start with Default PVC
-
-```bash
-# Use default storage class (fastest startup method)
-helm install curvine ./curvine-runtime -n curvine --create-namespace
-```
-
-#### Cloud Environment Fast SSD Configuration
-
-```bash
-# AWS/GCP/Azure fast SSD storage
-helm install curvine ./curvine-runtime -n curvine --create-namespace \
-  --set master.storage.meta.storageClass=fast-ssd \
-  --set master.storage.journal.storageClass=fast-ssd \
-  --set 'worker.storage.dataDirs[0].storageClass=fast-ssd' \
-  --set 'worker.storage.dataDirs[0].size=500Gi'
-```
-
-#### Bare Metal Multi-Storage Type Configuration
-
-```bash
-# Create values-baremetal-multi.yaml:
-# master:
-#   storage:
-#     meta:
-#       storageClass: ""
-#       hostPath: "/mnt/nvme/master/meta"
-#     journal:
-#       storageClass: ""
-#       hostPath: "/mnt/nvme/master/journal"
-# 
-# worker:
-#   storage:
-#     dataDirs:
-#       - name: "nvme"
-#         type: "SSD"
-#         enabled: true
-#         size: "200Gi"
-#         storageClass: ""
-#         hostPath: "/mnt/nvme/worker"
-#         mountPath: "/data/nvme"
-#       - name: "ssd"
-#         type: "SSD"
-#         enabled: true
-#         size: "500Gi"
-#         storageClass: ""
-#         hostPath: "/mnt/ssd/worker"
-#         mountPath: "/data/ssd"
-#       - name: "hdd"
-#         type: "HDD"
-#         enabled: true
-#         size: "2000Gi"
-#         storageClass: ""
-#         hostPath: "/mnt/hdd/worker"
-#         mountPath: "/data/hdd"
-
-helm install curvine ./curvine-runtime -n curvine --create-namespace \
-  -f values-baremetal-multi.yaml
-```
-
-#### Hybrid Cloud and Local Storage
-
-```bash
-# Master uses cloud PVC, Worker uses local hostPath
-helm install curvine ./curvine-runtime -n curvine --create-namespace \
-  --set master.storage.meta.storageClass=cloud-ssd \
-  --set master.storage.journal.storageClass=cloud-ssd \
-  --set 'worker.storage.dataDirs[0].storageClass=""' \
-  --set 'worker.storage.dataDirs[0].hostPath=/mnt/local/data'
+```text
+curvine-master-0.curvine-master.curvine.svc.cluster.local:8995,curvine-master-1.curvine-master.curvine.svc.cluster.local:8995,curvine-master-2.curvine-master.curvine.svc.cluster.local:8995
 ```
 
 ## Upgrade
 
-### Update Configuration
-
 ```bash
-# Scale Worker replicas (from Helm repository)
-helm upgrade curvine curvine/curvine -n curvine --devel \
-  --set worker.replicas=15
-
-# Upgrade image version (from Helm repository)
-helm upgrade curvine curvine/curvine -n curvine --devel \
-  --set image.tag=v1.1.0
-
-# Upgrade with new values file (from local Chart, run in helm-charts directory)
-helm upgrade curvine ./curvine-runtime -n curvine \
-  -f ./curvine-runtime/values-new.yaml
+helm upgrade curvine curvine/curvine \
+  --version 0.3.2-alpha \
+  -n curvine \
+  --reuse-values \
+  --set worker.replicas=3
 ```
 
->**Note**:
->1. Master replica count and journal storage class cannot be modified during upgrades. To modify, delete and redeploy the cluster.
->2. Parameters not modified during upgrade will be reset to default configuration. If Master replica count and journal storage class were modified during installation, these two parameters need to be included during updates.
-
-### Common Upgrade Scenarios
-
-#### Scale Worker Nodes
-
-```bash
-# Increase Worker replicas from 3 to 10
-helm upgrade curvine ./curvine-runtime -n curvine \
-  --set worker.replicas=10
-```
-
-#### Increase Resource Limits
-
-```bash
-# Increase Master resources for better performance
-helm upgrade curvine ./curvine-runtime -n curvine \
-  --set master.resources.limits.cpu=4000m \
-  --set master.resources.limits.memory=8Gi
-```
-
-#### Update Image Version
-
-```bash
-# Upgrade to new Curvine version
-helm upgrade curvine ./curvine-runtime -n curvine \
-  --set image.tag=v1.2.0
-```
-
-#### Enable Debug Logging
-
-```bash
-# Temporarily enable debug logging for troubleshooting
-helm upgrade curvine ./curvine-runtime -n curvine \
-  --set config.log.level=DEBUG
-```
-
-#### Change Storage Configuration
-
-```bash
-# Migrate to faster storage class
-helm upgrade curvine ./curvine-runtime -n curvine \
-  --set master.storage.meta.storageClass=ultra-ssd \
-  --set master.storage.journal.storageClass=ultra-ssd
-```
-
-### View Release History
-
-```bash
-helm history curvine -n curvine
-```
-
-### Rollback
-
-```bash
-# Rollback to previous version
-helm rollback curvine -n curvine
-
-# Rollback to specific version
-helm rollback curvine 2 -n curvine
-```
+`master.replicas` cannot be changed after install.
 
 ## Uninstall
 
 ```bash
-# Uninstall Chart (keep PVC)
 helm uninstall curvine -n curvine
-
-# Delete PersistentVolumeClaims
 kubectl delete pvc -n curvine -l app.kubernetes.io/instance=curvine
-
-# Delete namespace
 kubectl delete namespace curvine
 ```
 
 ## Troubleshooting
 
-### Check Pod Status
+| Symptom | Command | Cause |
+|---------|---------|-------|
+| Pod Pending | `kubectl describe pod -n curvine <name>` | Insufficient resources; no StorageClass |
+| Slow master startup | `kubectl logs curvine-master-0 -n curvine` | Raft replay in progress |
+| PVC Pending | `kubectl get sc` | No available StorageClass |
+
+## Configuration Reference
+
+### Cluster and images
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `cluster.id` | `curvine` | Cluster ID |
+| `image.repository` | `ghcr.io/curvineio/curvine` | Image repository |
+| `image.tag` | `""` | Empty uses `v{Chart.AppVersion}` |
+
+### Replicas and resources
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `master.replicas` | `1` | Must be odd |
+| `worker.replicas` | `1` | — |
+| `master.resources` | see values.yaml | — |
+| `worker.resources` | see values.yaml | — |
+
+### Storage
+
+| Mode | Configuration |
+|------|---------------|
+| PVC (default) | Cluster default StorageClass |
+| Named StorageClass | `master.storage.*.storageClass`, `worker.storage.dataDirs[].storageClass` |
+| hostPath | `storageClass: ""` with `hostPath`; see `values-baremetal.yaml` |
+
+### OpenKruise
+
+`openKruise.enabled` defaults to `false`. Master and worker use standard `apps/v1` StatefulSets without OpenKruise.
+
+Set to `true` to install the kruise subchart and switch master/worker to Advanced StatefulSet (`apps.kruise.io/v1beta1`):
+
+| Capability | Use case |
+|------------|----------|
+| In-place image update | Reduce pod recreation during image upgrades |
+| PersistentPodState | Prefer scheduling master pods back to the same node after recreation |
+
+| Parameter | Default |
+|-----------|---------|
+| `openKruise.enabled` | `false` |
+
+### Examples
+
+Lower resource requests:
 
 ```bash
-kubectl get pods -n curvine
-kubectl describe pod <pod-name> -n curvine
-kubectl logs <pod-name> -n curvine
+helm upgrade curvine curvine/curvine -n curvine --reuse-values \
+  --set master.resources.requests.cpu=200m \
+  --set master.resources.requests.memory=512Mi \
+  --set worker.resources.requests.cpu=200m \
+  --set worker.resources.requests.memory=512Mi
 ```
 
-### View ConfigMap
+Full parameter list:
 
 ```bash
-kubectl get configmap -n curvine
-kubectl describe configmap curvine-config -n curvine
+helm show values curvine/curvine --version 0.3.2-alpha
 ```
-
-### View Events
-
-```bash
-kubectl get events -n curvine --sort-by='.lastTimestamp'
-```
-
-### Common Issues
-
-1. **Master Replica Validation Failed**
-
-   1. Error: `master.replicas must be an odd number`
-
-   2. Solution: Ensure Master replica count is odd (1, 3, 5, 7...)
-
-2. **PVC Cannot Bind**
-
-   1. Check if StorageClass exists
-
-   2. Verify PV provisioner is working properly
-
-3. **Pod Startup Failed**
-
-   1. Verify container image exists
-
-   2. Check if resource quotas are sufficient
-
-   3. View Pod logs for details

--- a/docs/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/01-k8s-Deployment.md
+++ b/docs/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/01-k8s-Deployment.md
@@ -100,45 +100,164 @@ kubectl delete namespace curvine
 
 ## Configuration Reference
 
-### Cluster and images
+Chart version `0.3.2-alpha`. Defaults below match `helm show values curvine/curvine --version 0.3.2-alpha`.
+
+### Global
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `global.clusterDomain` | `cluster.local` | Kubernetes cluster domain |
+
+### Cluster
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `cluster.id` | `curvine` | Cluster ID |
-| `image.repository` | `ghcr.io/curvineio/curvine` | Image repository |
-| `image.tag` | `""` | Empty uses `v{Chart.AppVersion}` |
+| `cluster.formatMaster` | `false` | Format master data on startup |
+| `cluster.formatWorker` | `false` | Format worker data on startup |
+| `cluster.formatJournal` | `false` | Format journal data on startup |
 
-### Replicas and resources
+### Image
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `master.replicas` | `1` | Must be odd |
-| `worker.replicas` | `1` | — |
-| `master.resources` | see values.yaml | — |
-| `worker.resources` | see values.yaml | — |
-
-### Storage
-
-| Mode | Configuration |
-|------|---------------|
-| PVC (default) | Cluster default StorageClass |
-| Named StorageClass | `master.storage.*.storageClass`, `worker.storage.dataDirs[].storageClass` |
-| hostPath | `storageClass: ""` with `hostPath`; see `values-baremetal.yaml` |
+| `image.repository` | `ghcr.io/curvineio/curvine` | Image repository |
+| `image.tag` | `""` | Empty uses `v{Chart.AppVersion}` |
+| `image.pullPolicy` | `IfNotPresent` | Image pull policy |
+| `image.pullSecrets` | `[]` | Image pull secrets |
 
 ### OpenKruise
 
-`openKruise.enabled` defaults to `false`. Master and worker use standard `apps/v1` StatefulSets without OpenKruise.
+`openKruise.enabled` defaults to `false`. Master and worker use standard `apps/v1` StatefulSets.
 
-Set to `true` to install the kruise subchart and switch master/worker to Advanced StatefulSet (`apps.kruise.io/v1beta1`):
+Set `openKruise.enabled=true` to install the kruise subchart and switch master/worker to Advanced StatefulSet (`apps.kruise.io/v1beta1`).
 
-| Capability | Use case |
-|------------|----------|
-| In-place image update | Reduce pod recreation during image upgrades |
-| PersistentPodState | Prefer scheduling master pods back to the same node after recreation |
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `openKruise.enabled` | `false` | Enable Advanced StatefulSet |
+| `openKruise.podUpdatePolicy` | `InPlaceOnly` | `InPlaceOnly` \| `InPlaceIfPossible` \| `ReCreate` |
+| `openKruise.persistentPodState.autoGenerate` | `true` | Auto-generate PersistentPodState |
+| `openKruise.persistentPodState.preferredPersistentTopology` | `kubernetes.io/hostname` | Preferred topology key |
+| `openKruise.persistentPodState.requiredPersistentTopology` | `""` | Required topology key (optional) |
+| `kruise.installation.namespace` | `kruise-system` | Kruise subchart namespace (when enabled) |
+| `kruise.installation.createNamespace` | `true` | Create Kruise namespace |
 
-| Parameter | Default |
-|-----------|---------|
-| `openKruise.enabled` | `false` |
+### Master
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `master.replicas` | `1` | Must be odd (1, 3, 5, …) |
+| `master.rpcPort` | `8995` | RPC port |
+| `master.journalPort` | `8996` | Journal/Raft port |
+| `master.webPort` | `9000` | Web UI port |
+| `master.web1Port` | `9001` | Additional web port |
+| `master.startupProbe.enabled` | `true` | Startup probe |
+| `master.startupProbe.failureThreshold` | `90` | Allow long Raft replay |
+| `master.storage.meta.enabled` | `true` | Enable metadata PVC |
+| `master.storage.meta.storageClass` | `""` | Empty uses default StorageClass |
+| `master.storage.meta.size` | `5Gi` | Metadata PVC size |
+| `master.storage.meta.hostPath` | `""` | hostPath when no StorageClass |
+| `master.storage.meta.mountPath` | `/opt/curvine/data/meta` | Mount path |
+| `master.storage.journal.enabled` | `true` | Enable journal PVC |
+| `master.storage.journal.storageClass` | `""` | Empty uses default StorageClass |
+| `master.storage.journal.size` | `10Gi` | Journal PVC size |
+| `master.storage.journal.hostPath` | `""` | hostPath when no StorageClass |
+| `master.storage.journal.mountPath` | `/opt/curvine/data/journal` | Mount path |
+| `master.resources.requests.cpu` | `500m` | CPU request |
+| `master.resources.requests.memory` | `1Gi` | Memory request |
+| `master.resources.limits.cpu` | `1000m` | CPU limit |
+| `master.resources.limits.memory` | `2Gi` | Memory limit |
+| `master.antiAffinity.enabled` | `false` | Pod anti-affinity |
+| `master.antiAffinity.type` | `required` | `required` or `preferred` |
+| `master.persistentTopology.enabled` | `true` | PersistentPodState topology |
+| `master.persistentTopology.key` | `kubernetes.io/hostname` | Topology key |
+| `master.nodeSelector` | `{}` | Node selector |
+| `master.tolerations` | `[]` | Tolerations |
+| `master.affinity` | `{}` | Affinity rules |
+
+### Worker
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `worker.replicas` | `1` | Worker replica count |
+| `worker.rpcPort` | `8997` | RPC port |
+| `worker.webPort` | `9001` | Web UI port |
+| `worker.s3Gateway.enabled` | `false` | Enable S3 gateway |
+| `worker.s3Gateway.listen` | `0.0.0.0:9900` | S3 gateway listen address |
+| `worker.s3Gateway.enableDistributedAuth` | `true` | Distributed auth for S3 |
+| `worker.s3Gateway.service.type` | `ClusterIP` | S3 service type |
+| `worker.hostNetwork` | `false` | Use host network |
+| `worker.dnsPolicy` | `ClusterFirst` | DNS policy |
+| `worker.usePodIPAsHostname` | `false` | Use Pod IP as worker hostname |
+| `worker.privileged` | `true` | Privileged mode (FUSE) |
+| `worker.storage.dataDirs[0].name` | `data1` | Data directory name |
+| `worker.storage.dataDirs[0].type` | `SSD` | Storage type |
+| `worker.storage.dataDirs[0].enabled` | `true` | Enable data directory |
+| `worker.storage.dataDirs[0].size` | `20Gi` | PVC size |
+| `worker.storage.dataDirs[0].storageClass` | `""` | Empty uses default StorageClass |
+| `worker.storage.dataDirs[0].hostPath` | `""` | hostPath when no StorageClass |
+| `worker.storage.dataDirs[0].mountPath` | `/data/data1` | Mount path |
+| `worker.resources.requests.cpu` | `500m` | CPU request |
+| `worker.resources.requests.memory` | `1Gi` | Memory request |
+| `worker.resources.limits.cpu` | `1000m` | CPU limit |
+| `worker.resources.limits.memory` | `2Gi` | Memory limit |
+| `worker.antiAffinity.enabled` | `true` | Pod anti-affinity |
+| `worker.antiAffinity.type` | `preferred` | `required` or `preferred` |
+| `worker.nodeSelector` | `{}` | Node selector |
+| `worker.tolerations` | `[]` | Tolerations |
+| `worker.affinity` | `{}` | Affinity rules |
+
+### Service
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `service.master.type` | `ClusterIP` | Headless (`ClusterIP: None`) |
+| `service.worker.type` | `ClusterIP` | Headless (`ClusterIP: None`) |
+| `service.masterExternal.enabled` | `false` | External master access |
+| `service.masterExternal.type` | `ClusterIP` | External service type |
+| `service.masterExternal.loadBalancerIP` | `""` | LoadBalancer IP |
+
+### Service account and RBAC
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `serviceAccount.create` | `true` | Create ServiceAccount |
+| `serviceAccount.name` | `""` | Auto-generated when empty |
+| `rbac.create` | `true` | Create RBAC resources |
+
+### Curvine config (`config.*`)
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `config.master.metaDir` | `/opt/curvine/data/meta` | Master metadata directory |
+| `config.journal.enable` | `true` | Enable journal |
+| `config.journal.journalDir` | `/opt/curvine/data/journal` | Journal directory |
+| `config.journal.snapshotInterval` | `6h` | Snapshot interval |
+| `config.journal.snapshotEntries` | `1000000` | Snapshot entry threshold |
+| `config.client.blockSizeStr` | `64MB` | Client block size |
+| `config.log.level` | `INFO` | Log level |
+| `config.log.logDir` | `/opt/curvine/logs` | Log directory |
+| `config.log.console` | `true` | Route logs to stdout |
+
+### Config overrides (`configOverrides.*`)
+
+Override individual TOML sections without replacing the full config:
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `configOverrides.master` | `{}` | Master section overrides |
+| `configOverrides.journal` | `{}` | Journal section overrides |
+| `configOverrides.worker` | `{}` | Worker section overrides |
+| `configOverrides.client` | `{}` | Client section overrides |
+| `configOverrides.log` | `{}` | Log section overrides |
+
+### Storage modes
+
+| Mode | Configuration |
+|------|---------------|
+| PVC (default) | `storageClass: ""` uses cluster default StorageClass |
+| Named StorageClass | `master.storage.*.storageClass`, `worker.storage.dataDirs[].storageClass` |
+| hostPath | `storageClass: ""` with `hostPath` set |
 
 ### Examples
 

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/01-k8s-Deployment.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/01-k8s-Deployment.md
@@ -2,613 +2,158 @@
 sidebar_position: 0
 ---
 
-# k8s部署
-本章节介绍如何在 Kubernetes 上部署 Curvine 分布式存储集群的生产级 Helm Chart。
+# Kubernetes 部署
+
+Chart：`curvine/curvine`，版本 `0.3.2-alpha`。
 
 ## 前置条件
 
-* Kubernetes 1.20+
-* Helm 3.0+
-* PV 供应器（如果使用 PVC 存储）
+- Kubernetes 1.20+
+- Helm 3.x
+- 集群具备默认 `StorageClass`（供 master/worker PVC 使用）
 
-## 快速开始
+## 架构说明
 
-### 1. 将镜像载入 Kubernetes 集群
+Helm release `curvine` 部署于 namespace `curvine`：
 
-参考[docker编译](../1-Preparation/02-compile.md#docker编译)构建镜像，将镜像导入到 Kubernetes 集群中。
+| 资源 | 说明 |
+|------|------|
+| StatefulSet `curvine-master` | 元数据、Raft journal |
+| StatefulSet `curvine-worker` | 数据节点 |
+| Service `curvine-master` | Headless，RPC 8995 |
+| Service `curvine-worker` | Headless，RPC 8997 |
 
-### 2. 添加 Helm 仓库（可选）
+默认 `openKruise.enabled=false`，StatefulSet 使用 `apps/v1`。
+
+## 部署
+
+### 添加仓库
 
 ```bash
-# 如果 Chart 已发布到仓库
 helm repo add curvine https://curvineio.github.io/helm-charts
 helm repo update
 ```
-### 3. 安装 Chart
 
-#### 选项 A：从 Helm 仓库安装（推荐）
+### 安装
 
->**提示**：当前helm提供的版本基于main分支版本，仅在预发模式下使用，如需安装需要指定--devel 
 ```bash
-# 使用默认配置安装
-helm install curvine curvine/curvine -n curvine --create-namespace --devel
-
-# 使用自定义副本数安装
-helm install curvine curvine/curvine -n curvine --create-namespace --devel \
-  --set master.replicas=5 \
-  --set worker.replicas=10
-
-# 使用自定义 values 文件安装
-helm install curvine curvine/curvine -n curvine --create-namespace --devel \
-  -f https://curvineio.github.io/helm/charts/examples/values-prod.yaml
+helm upgrade --install curvine curvine/curvine \
+  --version 0.3.2-alpha \
+  -n curvine \
+  --create-namespace \
+  --wait --timeout 10m
 ```
-#### 选项 B：从本地 Chart 安装
 
->**注意**：从 `helm-charts` 目录（`curvine-runtime` 文件夹的父目录）运行这些命令 
+### 验证
+
 ```bash
-# 使用默认配置安装
-helm install curvine ./curvine-runtime -n curvine --create-namespace
-
-# 使用自定义副本数安装
-helm install curvine ./curvine-runtime -n curvine --create-namespace \
-  --set master.replicas=5 \
-  --set worker.replicas=10
-
-# 使用自定义 values 文件安装
-helm install curvine ./curvine-runtime -n curvine --create-namespace \
-  -f ./curvine-runtime/examples/values-prod.yaml
+kubectl get pods,svc,pvc -n curvine
 ```
-### 4. 验证部署
+
+Web UI：
 
 ```bash
-# 检查 Pod 状态
-kubectl get pods -n curvine
-
-# 查看 Services
-kubectl get svc -n curvine
-
-# 查看 PersistentVolumeClaims
-kubectl get pvc -n curvine
-
-# 运行 Helm 测试
-helm test curvine -n curvine
-```
-### 5. 访问集群
-
-```bash
-# 端口转发访问 Master Web UI
 kubectl port-forward -n curvine svc/curvine-master 9000:9000
-
-# 访问 http://localhost:9000
-```
-## 配置
-
-### 查看当前配置
-
-```bash
-# 查看所有当前值
-helm get values curvine -n curvine
-
-# 以 YAML 格式查看特定版本的值
-helm get values curvine -n curvine -o yaml
-
-# 查看渲染后的清单
-helm get manifest curvine -n curvine
-
-# 查看 Chart 的 values.yaml
-cat ./curvine-runtime/values.yaml
-
-# 查看特定参数
-helm get values curvine -n curvine | grep master.replicas
 ```
 
-### 常见参数使用示例
+### Master 地址
 
-#### 调整资源限制
+单副本：
 
-```bash
-# 为高负载场景增加 Master 资源
-helm install curvine ./curvine-runtime -n curvine --create-namespace \
-  --set master.resources.requests.cpu=2000m \
-  --set master.resources.requests.memory=4Gi \
-  --set master.resources.limits.cpu=4000m \
-  --set master.resources.limits.memory=8Gi
-```
-#### 配置节点亲和性
-
-```bash
-# 在特定节点上运行 Master
-helm install curvine ./curvine-runtime -n curvine --create-namespace \
-  --set 'master.nodeSelector.node-type=master' \
-  --set 'worker.nodeSelector.node-type=worker'
-```
-#### 启用 Worker 特权模式
-
-```bash
-# 默认已启用，但可根据需要禁用
-helm install curvine ./curvine-runtime -n curvine --create-namespace \
-  --set worker.privileged=false
-```
-#### 为 Worker 配置多个数据目录
-
-```bash
-# 创建 values-multi-data.yaml，内容如下：
-# worker:
-#   storage:
-#     dataDirs:
-#       - name: "data1"
-#         type: "SSD"
-#         enabled: true
-#         size: "100Gi"
-#         storageClass: "fast-ssd"
-#         mountPath: "/data/data1"
-#       - name: "data2"
-#         type: "HDD"
-#         enabled: true
-#         size: "500Gi"
-#         storageClass: "slow-hdd"
-#         mountPath: "/data/data2"
-
-helm install curvine ./curvine-runtime -n curvine --create-namespace \
-  -f values-multi-data.yaml
-```
-#### 调整日志级别
-
-```bash
-# 设置日志级别为 DEBUG 用于故障排查
-helm install curvine ./curvine-runtime -n curvine --create-namespace \
-  --set config.log.level=DEBUG
-```
-#### 配置外部 Master Service
-
-```bash
-# 通过 LoadBalancer 暴露 Master Service
-helm install curvine ./curvine-runtime -n curvine --create-namespace \
-  --set service.masterExternal.enabled=true \
-  --set service.masterExternal.type=LoadBalancer
+```text
+curvine-master.curvine.svc.cluster.local:8995
 ```
 
-### 配置参数
+三副本：
 
-#### 全局参数
-
-|参数|说明|默认值|
-|:----|:----|:----|
-|global.clusterDomain|Kubernetes 集群域|cluster.local|
-
-#### 集群参数
-
-|参数|说明|默认值|
-|:----|:----|:----|
-|cluster.id|集群标识符|curvine|
-|cluster.formatMaster|启动时格式化 Master 数据|false|
-|cluster.formatWorker|启动时格式化 Worker 数据|false|
-|cluster.formatJournal|启动时格式化日志数据|false|
-
-#### 镜像配置
-
-|参数|说明|默认值|
-|:----|:----|:----|
-|image.repository|容器镜像仓库|docker.io/curvine|
-|image.tag|容器镜像标签|latest|
-|image.pullPolicy|镜像拉取策略|IfNotPresent|
-|image.pullSecrets|镜像拉取密钥|[]|
-
-#### Master 配置
-
-|参数|说明|默认值|
-|:----|:----|:----|
-|master.replicas|Master 副本数（必须为奇数：1, 3, 5, 7…）|3|
-|master.rpcPort|RPC 端口|8995|
-|master.journalPort|日志/Raft 端口|8996|
-|master.webPort|Web UI 端口|9000|
-|master.web1Port|额外 Web 端口|9001|
-|master.storage.meta.enabled|启用元数据存储|true|
-|master.storage.meta.storageClass|元数据存储类|"" (默认)|
-|master.storage.meta.size|元数据存储大小|10Gi|
-|master.storage.meta.hostPath|元数据主机路径（无 storageClass 时使用）|""|
-|master.storage.meta.mountPath|元数据挂载路径|/opt/curvine/data/meta|
-|master.storage.journal.enabled|启用日志存储|true|
-|master.storage.journal.storageClass|日志存储类|"" (默认)|
-|master.storage.journal.size|日志存储大小|50Gi|
-|master.storage.journal.hostPath|日志主机路径（无 storageClass 时使用）|""|
-|master.storage.journal.mountPath|日志挂载路径|/opt/curvine/data/journal|
-|master.resources.requests.cpu|CPU 请求|1000m|
-|master.resources.requests.memory|内存请求|2Gi|
-|master.resources.limits.cpu|CPU 限制|2000m|
-|master.resources.limits.memory|内存限制|4Gi|
-|master.nodeSelector|节点选择器标签|{}|
-|master.tolerations|Pod 容忍度|[]|
-|master.affinity|Pod 亲和性规则|{}|
-|master.labels|额外标签|{}|
-|master.annotations|额外注解|{}|
-|master.extraEnv|额外环境变量|[]|
-|master.extraVolumes|额外卷|[]|
-|master.extraVolumeMounts|额外卷挂载|[]|
-
-#### Worker 配置
-
-|参数|说明|默认值|
-|:----|:----|:----|
-|worker.replicas|Worker 副本数|3|
-|worker.rpcPort|RPC 端口|8997|
-|worker.webPort|Web UI 端口|9001|
-|worker.hostNetwork|使用主机网络|false|
-|worker.dnsPolicy|DNS 策略|ClusterFirst|
-|worker.privileged|特权模式（FUSE 需要）|true|
-|worker.storage.dataDirs[0].name|数据目录名称|data1|
-|worker.storage.dataDirs[0].type|存储类型（SSD/HDD）|SSD|
-|worker.storage.dataDirs[0].enabled|启用数据目录|true|
-|worker.storage.dataDirs[0].size|数据目录大小|10Gi|
-|worker.storage.dataDirs[0].storageClass|存储类|"" (默认)|
-|worker.storage.dataDirs[0].hostPath|主机路径（无 storageClass 时使用）|""|
-|worker.storage.dataDirs[0].mountPath|挂载路径|/data/data1|
-|worker.resources.requests.cpu|CPU 请求|2000m|
-|worker.resources.requests.memory|内存请求|4Gi|
-|worker.resources.limits.cpu|CPU 限制|4000m|
-|worker.resources.limits.memory|内存限制|8Gi|
-|worker.nodeSelector|节点选择器标签|{}|
-|worker.tolerations|Pod 容忍度|[]|
-|worker.antiAffinity.enabled|启用 Pod 反亲和性|true|
-|worker.antiAffinity.type|反亲和性类型（required/preferred）|preferred|
-|worker.labels|额外标签|{}|
-|worker.annotations|额外注解|{}|
-|worker.extraEnv|额外环境变量|[]|
-|worker.extraVolumes|额外卷|[]|
-|worker.extraVolumeMounts|额外卷挂载|[]|
-
-#### Service 配置
-
-|参数|说明|默认值|
-|:----|:----|:----|
-|service.master.type|Master Service 类型|ClusterIP|
-|service.master.annotations|Master Service 注解|{}|
-|service.masterExternal.enabled|启用外部 Master Service|false|
-|service.masterExternal.type|外部 Service 类型|ClusterIP|
-|service.masterExternal.annotations|外部 Service 注解|{}|
-|service.masterExternal.nodePort|NodePort 配置|{}|
-|service.masterExternal.loadBalancerIP|LoadBalancer IP|""|
-|service.masterExternal.loadBalancerSourceRanges|LoadBalancer 源范围|[]|
-
-#### Service Account & RBAC
-
-|参数|说明|默认值|
-|:----|:----|:----|
-|serviceAccount.create|创建 Service Account|true|
-|serviceAccount.name|Service Account 名称|"" (自动生成)|
-|serviceAccount.annotations|Service Account 注解|{}|
-|rbac.create|创建 RBAC 资源|true|
-
-#### Curvine 配置
-
-|参数|说明|默认值|
-|:----|:----|:----|
-|config.master.metaDir|Master 元数据目录|/opt/curvine/data/meta|
-|config.journal.enable|启用日志|true|
-|config.journal.journalDir|日志目录|/opt/curvine/data/journal|
-|config.client.blockSizeStr|客户端块大小|64MB|
-|config.log.level|日志级别（INFO/DEBUG/WARN/ERROR）|INFO|
-|config.log.logDir|日志目录|/opt/curvine/logs|
-|configOverrides.master|Master 配置覆盖|{}|
-|configOverrides.journal|日志配置覆盖|{}|
-|configOverrides.worker|Worker 配置覆盖|{}|
-|configOverrides.client|客户端配置覆盖|{}|
-|configOverrides.log|日志配置覆盖|{}|
-
-完整的参数列表请参考 `values.yaml`。
-
-## 配置示例
-
-### 开发环境（最小化）
-
-```bash
-# 从 Helm 仓库安装
-helm install curvine curvine/curvine -n curvine --create-namespace --devel \
-  --set master.replicas=1 \
-  --set worker.replicas=1
-
-# 从本地 Chart 安装（在 helm-charts 目录运行）
-helm install curvine ./curvine-runtime -n curvine --create-namespace \
-  -f ./curvine-runtime/examples/values-dev.yaml
+```text
+curvine-master-0.curvine-master.curvine.svc.cluster.local:8995,curvine-master-1.curvine-master.curvine.svc.cluster.local:8995,curvine-master-2.curvine-master.curvine.svc.cluster.local:8995
 ```
-### 生产环境（高可用）
 
-```bash
-# 从 Helm 仓库安装
-helm install curvine curvine/curvine -n curvine --create-namespace --devel \
-  --set master.replicas=5 \
-  --set worker.replicas=10 \
-  --set master.storage.meta.storageClass=fast-ssd \
-  --set master.storage.journal.storageClass=fast-ssd
-
-# 从本地 Chart 安装（在 helm-charts 目录运行）
-helm install curvine ./curvine-runtime -n curvine --create-namespace \
-  -f ./curvine-runtime/examples/values-prod.yaml
-```
-### 裸机环境（使用 hostPath）
-
-```bash
-# 从本地 Chart 安装（在 helm-charts 目录运行）
-helm install curvine ./curvine-runtime -n curvine --create-namespace \
-  -f ./curvine-runtime/examples/values-baremetal.yaml
-```
-### 自定义配置
-
-```bash
-# 从 Helm 仓库安装
-helm install curvine curvine/curvine -n curvine --create-namespace --devel \
-  --set master.replicas=5 \
-  --set worker.replicas=10 \
-  --set master.storage.meta.storageClass=fast-ssd \
-  --set worker.storage.dataDirs[0].storageClass=fast-ssd \
-  --set worker.storage.dataDirs[0].size=500Gi
-
-# 从本地 Chart 安装（在 helm-charts 目录运行）
-helm install curvine ./curvine-runtime -n curvine --create-namespace \
-  --set master.replicas=5 \
-  --set worker.replicas=10 \
-  --set master.storage.meta.storageClass=fast-ssd \
-  --set worker.storage.dataDirs[0].storageClass=fast-ssd \
-  --set worker.storage.dataDirs[0].size=500Gi
-```
-## 存储配置
-
-### 使用 PVC（推荐用于云环境）
-
-```yaml
-master:
-  storage:
-    meta:
-      storageClass: "fast-ssd"
-      size: "20Gi"
-    journal:
-      storageClass: "fast-ssd"
-      size: "100Gi"
-
-worker:
-  storage:
-    dataDirs:
-      - name: "data1"
-        type: "SSD"
-        enabled: true
-        size: "100Gi"
-        storageClass: "fast-ssd"
-        mountPath: "/data/data1"
-```
-### 使用 hostPath（推荐用于裸机）
-
-```yaml
-master:
-  storage:
-    meta:
-      storageClass: ""
-      hostPath: "/mnt/curvine/master/meta"
-    journal:
-      storageClass: ""
-      hostPath: "/mnt/curvine/master/journal"
-
-worker:
-  storage:
-    dataDirs:
-      - name: "data1"
-        type: "SSD"
-        enabled: true
-        size: "100Gi"
-        storageClass: ""
-        hostPath: "/mnt/nvme0n1/curvine"
-        mountPath: "/data/data1"
-```
-### 使用 emptyDir（用于测试）
-
-```yaml
-master:
-  storage:
-    meta:
-      storageClass: ""
-      hostPath: ""
-    journal:
-      storageClass: ""
-      hostPath: ""
-
-worker:
-  storage:
-    dataDirs:
-      - name: "data1"
-        storageClass: ""
-        hostPath: ""
-```
-### 存储配置示例
-
-#### 使用默认 PVC 快速启动
-
-```bash
-# 使用默认存储类（最快的启动方式）
-helm install curvine ./curvine-runtime -n curvine --create-namespace
-```
-#### 云环境配置快速 SSD
-
-```bash
-# AWS/GCP/Azure 快速 SSD 存储
-helm install curvine ./curvine-runtime -n curvine --create-namespace \
-  --set master.storage.meta.storageClass=fast-ssd \
-  --set master.storage.journal.storageClass=fast-ssd \
-  --set 'worker.storage.dataDirs[0].storageClass=fast-ssd' \
-  --set 'worker.storage.dataDirs[0].size=500Gi'
-```
-#### 裸机多存储类型配置
-
-```bash
-# 创建 values-baremetal-multi.yaml：
-# master:
-#   storage:
-#     meta:
-#       storageClass: ""
-#       hostPath: "/mnt/nvme/master/meta"
-#     journal:
-#       storageClass: ""
-#       hostPath: "/mnt/nvme/master/journal"
-# 
-# worker:
-#   storage:
-#     dataDirs:
-#       - name: "nvme"
-#         type: "SSD"
-#         enabled: true
-#         size: "200Gi"
-#         storageClass: ""
-#         hostPath: "/mnt/nvme/worker"
-#         mountPath: "/data/nvme"
-#       - name: "ssd"
-#         type: "SSD"
-#         enabled: true
-#         size: "500Gi"
-#         storageClass: ""
-#         hostPath: "/mnt/ssd/worker"
-#         mountPath: "/data/ssd"
-#       - name: "hdd"
-#         type: "HDD"
-#         enabled: true
-#         size: "2000Gi"
-#         storageClass: ""
-#         hostPath: "/mnt/hdd/worker"
-#         mountPath: "/data/hdd"
-
-helm install curvine ./curvine-runtime -n curvine --create-namespace \
-  -f values-baremetal-multi.yaml
-```
-#### 混合云和本地存储
-
-```bash
-# Master 使用云 PVC，Worker 使用本地 hostPath
-helm install curvine ./curvine-runtime -n curvine --create-namespace \
-  --set master.storage.meta.storageClass=cloud-ssd \
-  --set master.storage.journal.storageClass=cloud-ssd \
-  --set 'worker.storage.dataDirs[0].storageClass=""' \
-  --set 'worker.storage.dataDirs[0].hostPath=/mnt/local/data'
-```
 ## 升级
 
-### 更新配置
-
 ```bash
-# 扩展 Worker 副本数（从 Helm 仓库）
-helm upgrade curvine curvine/curvine -n curvine --devel \
-  --set worker.replicas=15
-
-# 升级镜像版本（从 Helm 仓库）
-helm upgrade curvine curvine/curvine -n curvine --devel \
-  --set image.tag=v1.1.0
-
-# 使用新 values 文件升级（从本地 Chart，在 helm-charts 目录运行）
-helm upgrade curvine ./curvine-runtime -n curvine \
-  -f ./curvine-runtime/values-new.yaml
+helm upgrade curvine curvine/curvine \
+  --version 0.3.2-alpha \
+  -n curvine \
+  --reuse-values \
+  --set worker.replicas=3
 ```
->**注意**：
->1.升级期间无法修改 Master 副本数和日志存储类。要修改请删除并重新部署集群。
->2.升级期间没有修改的参数会被重设为默认配置。如果在安装时修改了 Master 副本数和日志存储类，需要在更新时带上这两个参数。
-### 常见升级场景
 
-#### 扩展 Worker 节点
+`master.replicas` 安装后不可修改。
 
-```bash
-# 将 Worker 副本数从 3 增加到 10
-helm upgrade curvine ./curvine-runtime -n curvine \
-  --set worker.replicas=10
-```
-#### 增加资源限制
-
-```bash
-# 提升 Master 资源以获得更好的性能
-helm upgrade curvine ./curvine-runtime -n curvine \
-  --set master.resources.limits.cpu=4000m \
-  --set master.resources.limits.memory=8Gi
-```
-#### 更新镜像版本
-
-```bash
-# 升级到新的 Curvine 版本
-helm upgrade curvine ./curvine-runtime -n curvine \
-  --set image.tag=v1.2.0
-```
-#### 启用调试日志
-
-```bash
-# 临时启用调试日志用于故障排查
-helm upgrade curvine ./curvine-runtime -n curvine \
-  --set config.log.level=DEBUG
-```
-#### 更改存储配置
-
-```bash
-# 迁移到更快的存储类
-helm upgrade curvine ./curvine-runtime -n curvine \
-  --set master.storage.meta.storageClass=ultra-ssd \
-  --set master.storage.journal.storageClass=ultra-ssd
-```
-### 查看发布历史
-
-```bash
-helm history curvine -n curvine
-```
-### 回滚
-
-```bash
-# 回滚到上一个版本
-helm rollback curvine -n curvine
-
-# 回滚到特定版本
-helm rollback curvine 2 -n curvine
-```
 ## 卸载
 
 ```bash
-# 卸载 Chart（保留 PVC）
 helm uninstall curvine -n curvine
-
-# 删除 PersistentVolumeClaims
 kubectl delete pvc -n curvine -l app.kubernetes.io/instance=curvine
-
-# 删除命名空间
 kubectl delete namespace curvine
 ```
+
 ## 故障排查
 
-### 检查 Pod 状态
+| 现象 | 命令 | 原因 |
+|------|------|------|
+| Pod Pending | `kubectl describe pod -n curvine <name>` | 资源不足；无 StorageClass |
+| master 启动慢 | `kubectl logs curvine-master-0 -n curvine` | Raft 回放中 |
+| PVC Pending | `kubectl get sc` | 无可用 StorageClass |
+
+## 配置参考
+
+### 集群与镜像
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `cluster.id` | `curvine` | 集群 ID |
+| `image.repository` | `ghcr.io/curvineio/curvine` | 镜像仓库 |
+| `image.tag` | `""` | 空值使用 `v{Chart.AppVersion}` |
+
+### 副本与资源
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `master.replicas` | `1` | 须为奇数 |
+| `worker.replicas` | `1` | — |
+| `master.resources` | 见 values.yaml | — |
+| `worker.resources` | 见 values.yaml | — |
+
+### 存储
+
+| 方式 | 配置 |
+|------|------|
+| PVC（默认） | 使用集群 default StorageClass |
+| 指定 StorageClass | `master.storage.*.storageClass`、`worker.storage.dataDirs[].storageClass` |
+| hostPath | `storageClass: ""` 并设置 `hostPath`，见 `values-baremetal.yaml` |
+
+### OpenKruise
+
+默认 `openKruise.enabled=false`，master/worker 使用标准 `apps/v1` StatefulSet，不安装 OpenKruise。
+
+设为 `true` 时安装 kruise 子 chart，并将 master/worker 切换为 Advanced StatefulSet（`apps.kruise.io/v1beta1`）：
+
+| 能力 | 场景 |
+|------|------|
+| 原地镜像更新（InPlaceUpdate） | 升级镜像时减少 Pod 重建 |
+| PersistentPodState | master Pod 重建后尽量调度回原节点 |
+
+| 参数 | 默认值 |
+|------|--------|
+| `openKruise.enabled` | `false` |
+
+### 示例
+
+降低资源 request：
 
 ```bash
-kubectl get pods -n curvine
-kubectl describe pod <pod-name> -n curvine
-kubectl logs <pod-name> -n curvine
+helm upgrade curvine curvine/curvine -n curvine --reuse-values \
+  --set master.resources.requests.cpu=200m \
+  --set master.resources.requests.memory=512Mi \
+  --set worker.resources.requests.cpu=200m \
+  --set worker.resources.requests.memory=512Mi
 ```
-### 查看 ConfigMap
+
+完整参数：
 
 ```bash
-kubectl get configmap -n curvine
-kubectl describe configmap curvine-config -n curvine
+helm show values curvine/curvine --version 0.3.2-alpha
 ```
-### 查看事件
-
-```bash
-kubectl get events -n curvine --sort-by='.lastTimestamp'
-```
-### 常见问题
-
-1. **Master 副本验证失败**
-
-   1. 错误：`master.replicas must be an odd number`
-
-   2. 解决方案：确保 Master 副本数为奇数（1, 3, 5, 7…）
-
-2. **PVC 无法绑定**
-
-   1. 检查 StorageClass 是否存在
-
-   2. 验证 PV 供应器是否正常工作
-
-3. **Pod 启动失败**
-
-   1. 验证容器镜像是否存在
-
-   2. 检查资源配额是否充足
-
-   3. 查看 Pod 日志了解详情

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/01-k8s-Deployment.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/01-k8s-Deployment.md
@@ -100,45 +100,164 @@ kubectl delete namespace curvine
 
 ## 配置参考
 
-### 集群与镜像
+Chart 版本 `0.3.2-alpha`。下表默认值与 `helm show values curvine/curvine --version 0.3.2-alpha` 一致。
+
+### 全局
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `global.clusterDomain` | `cluster.local` | Kubernetes 集群域名 |
+
+### 集群
 
 | 参数 | 默认值 | 说明 |
 |------|--------|------|
 | `cluster.id` | `curvine` | 集群 ID |
-| `image.repository` | `ghcr.io/curvineio/curvine` | 镜像仓库 |
-| `image.tag` | `""` | 空值使用 `v{Chart.AppVersion}` |
+| `cluster.formatMaster` | `false` | 启动时格式化 master 数据 |
+| `cluster.formatWorker` | `false` | 启动时格式化 worker 数据 |
+| `cluster.formatJournal` | `false` | 启动时格式化 journal 数据 |
 
-### 副本与资源
+### 镜像
 
 | 参数 | 默认值 | 说明 |
 |------|--------|------|
-| `master.replicas` | `1` | 须为奇数 |
-| `worker.replicas` | `1` | — |
-| `master.resources` | 见 values.yaml | — |
-| `worker.resources` | 见 values.yaml | — |
-
-### 存储
-
-| 方式 | 配置 |
-|------|------|
-| PVC（默认） | 使用集群 default StorageClass |
-| 指定 StorageClass | `master.storage.*.storageClass`、`worker.storage.dataDirs[].storageClass` |
-| hostPath | `storageClass: ""` 并设置 `hostPath`，见 `values-baremetal.yaml` |
+| `image.repository` | `ghcr.io/curvineio/curvine` | 镜像仓库 |
+| `image.tag` | `""` | 空值使用 `v{Chart.AppVersion}` |
+| `image.pullPolicy` | `IfNotPresent` | 镜像拉取策略 |
+| `image.pullSecrets` | `[]` | 镜像拉取密钥 |
 
 ### OpenKruise
 
-默认 `openKruise.enabled=false`，master/worker 使用标准 `apps/v1` StatefulSet，不安装 OpenKruise。
+默认 `openKruise.enabled=false`，master/worker 使用标准 `apps/v1` StatefulSet。
 
-设为 `true` 时安装 kruise 子 chart，并将 master/worker 切换为 Advanced StatefulSet（`apps.kruise.io/v1beta1`）：
+设 `openKruise.enabled=true` 时安装 kruise 子 chart，并将 master/worker 切换为 Advanced StatefulSet（`apps.kruise.io/v1beta1`）。
 
-| 能力 | 场景 |
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `openKruise.enabled` | `false` | 启用 Advanced StatefulSet |
+| `openKruise.podUpdatePolicy` | `InPlaceOnly` | `InPlaceOnly` \| `InPlaceIfPossible` \| `ReCreate` |
+| `openKruise.persistentPodState.autoGenerate` | `true` | 自动生成 PersistentPodState |
+| `openKruise.persistentPodState.preferredPersistentTopology` | `kubernetes.io/hostname` | 首选拓扑键 |
+| `openKruise.persistentPodState.requiredPersistentTopology` | `""` | 强制拓扑键（可选） |
+| `kruise.installation.namespace` | `kruise-system` | Kruise 子 chart 命名空间（启用时） |
+| `kruise.installation.createNamespace` | `true` | 创建 Kruise 命名空间 |
+
+### Master
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `master.replicas` | `1` | 须为奇数（1、3、5…） |
+| `master.rpcPort` | `8995` | RPC 端口 |
+| `master.journalPort` | `8996` | Journal/Raft 端口 |
+| `master.webPort` | `9000` | Web UI 端口 |
+| `master.web1Port` | `9001` | 附加 Web 端口 |
+| `master.startupProbe.enabled` | `true` | 启动探针 |
+| `master.startupProbe.failureThreshold` | `90` | 允许较长 Raft 回放 |
+| `master.storage.meta.enabled` | `true` | 启用元数据 PVC |
+| `master.storage.meta.storageClass` | `""` | 空值使用 default StorageClass |
+| `master.storage.meta.size` | `5Gi` | 元数据 PVC 大小 |
+| `master.storage.meta.hostPath` | `""` | 无 StorageClass 时使用 hostPath |
+| `master.storage.meta.mountPath` | `/opt/curvine/data/meta` | 挂载路径 |
+| `master.storage.journal.enabled` | `true` | 启用 journal PVC |
+| `master.storage.journal.storageClass` | `""` | 空值使用 default StorageClass |
+| `master.storage.journal.size` | `10Gi` | journal PVC 大小 |
+| `master.storage.journal.hostPath` | `""` | 无 StorageClass 时使用 hostPath |
+| `master.storage.journal.mountPath` | `/opt/curvine/data/journal` | 挂载路径 |
+| `master.resources.requests.cpu` | `500m` | CPU request |
+| `master.resources.requests.memory` | `1Gi` | 内存 request |
+| `master.resources.limits.cpu` | `1000m` | CPU limit |
+| `master.resources.limits.memory` | `2Gi` | 内存 limit |
+| `master.antiAffinity.enabled` | `false` | Pod 反亲和 |
+| `master.antiAffinity.type` | `required` | `required` 或 `preferred` |
+| `master.persistentTopology.enabled` | `true` | PersistentPodState 拓扑 |
+| `master.persistentTopology.key` | `kubernetes.io/hostname` | 拓扑键 |
+| `master.nodeSelector` | `{}` | 节点选择器 |
+| `master.tolerations` | `[]` | 容忍度 |
+| `master.affinity` | `{}` | 亲和规则 |
+
+### Worker
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `worker.replicas` | `1` | Worker 副本数 |
+| `worker.rpcPort` | `8997` | RPC 端口 |
+| `worker.webPort` | `9001` | Web UI 端口 |
+| `worker.s3Gateway.enabled` | `false` | 启用 S3 网关 |
+| `worker.s3Gateway.listen` | `0.0.0.0:9900` | S3 网关监听地址 |
+| `worker.s3Gateway.enableDistributedAuth` | `true` | S3 分布式认证 |
+| `worker.s3Gateway.service.type` | `ClusterIP` | S3 Service 类型 |
+| `worker.hostNetwork` | `false` | 使用 host 网络 |
+| `worker.dnsPolicy` | `ClusterFirst` | DNS 策略 |
+| `worker.usePodIPAsHostname` | `false` | 使用 Pod IP 作为 worker 主机名 |
+| `worker.privileged` | `true` | 特权模式（FUSE） |
+| `worker.storage.dataDirs[0].name` | `data1` | 数据目录名称 |
+| `worker.storage.dataDirs[0].type` | `SSD` | 存储类型 |
+| `worker.storage.dataDirs[0].enabled` | `true` | 启用数据目录 |
+| `worker.storage.dataDirs[0].size` | `20Gi` | PVC 大小 |
+| `worker.storage.dataDirs[0].storageClass` | `""` | 空值使用 default StorageClass |
+| `worker.storage.dataDirs[0].hostPath` | `""` | 无 StorageClass 时使用 hostPath |
+| `worker.storage.dataDirs[0].mountPath` | `/data/data1` | 挂载路径 |
+| `worker.resources.requests.cpu` | `500m` | CPU request |
+| `worker.resources.requests.memory` | `1Gi` | 内存 request |
+| `worker.resources.limits.cpu` | `1000m` | CPU limit |
+| `worker.resources.limits.memory` | `2Gi` | 内存 limit |
+| `worker.antiAffinity.enabled` | `true` | Pod 反亲和 |
+| `worker.antiAffinity.type` | `preferred` | `required` 或 `preferred` |
+| `worker.nodeSelector` | `{}` | 节点选择器 |
+| `worker.tolerations` | `[]` | 容忍度 |
+| `worker.affinity` | `{}` | 亲和规则 |
+
+### Service
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `service.master.type` | `ClusterIP` | Headless（`ClusterIP: None`） |
+| `service.worker.type` | `ClusterIP` | Headless（`ClusterIP: None`） |
+| `service.masterExternal.enabled` | `false` | 外部访问 master |
+| `service.masterExternal.type` | `ClusterIP` | 外部 Service 类型 |
+| `service.masterExternal.loadBalancerIP` | `""` | LoadBalancer IP |
+
+### ServiceAccount 与 RBAC
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `serviceAccount.create` | `true` | 创建 ServiceAccount |
+| `serviceAccount.name` | `""` | 空值自动生成 |
+| `rbac.create` | `true` | 创建 RBAC 资源 |
+
+### Curvine 配置（`config.*`）
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `config.master.metaDir` | `/opt/curvine/data/meta` | Master 元数据目录 |
+| `config.journal.enable` | `true` | 启用 journal |
+| `config.journal.journalDir` | `/opt/curvine/data/journal` | Journal 目录 |
+| `config.journal.snapshotInterval` | `6h` | 快照间隔 |
+| `config.journal.snapshotEntries` | `1000000` | 快照条目阈值 |
+| `config.client.blockSizeStr` | `64MB` | 客户端块大小 |
+| `config.log.level` | `INFO` | 日志级别 |
+| `config.log.logDir` | `/opt/curvine/logs` | 日志目录 |
+| `config.log.console` | `true` | 日志输出到 stdout |
+
+### 配置覆盖（`configOverrides.*`）
+
+按 TOML 分段覆盖，无需替换完整配置：
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `configOverrides.master` | `{}` | Master 段覆盖 |
+| `configOverrides.journal` | `{}` | Journal 段覆盖 |
+| `configOverrides.worker` | `{}` | Worker 段覆盖 |
+| `configOverrides.client` | `{}` | Client 段覆盖 |
+| `configOverrides.log` | `{}` | Log 段覆盖 |
+
+### 存储方式
+
+| 方式 | 配置 |
 |------|------|
-| 原地镜像更新（InPlaceUpdate） | 升级镜像时减少 Pod 重建 |
-| PersistentPodState | master Pod 重建后尽量调度回原节点 |
-
-| 参数 | 默认值 |
-|------|--------|
-| `openKruise.enabled` | `false` |
+| PVC（默认） | `storageClass: ""` 使用集群 default StorageClass |
+| 指定 StorageClass | `master.storage.*.storageClass`、`worker.storage.dataDirs[].storageClass` |
+| hostPath | `storageClass: ""` 并设置 `hostPath` |
 
 ### 示例
 


### PR DESCRIPTION
## Problem
The Kubernetes deployment page mixed quick start, dev/prod/bare-metal examples, and a full parameter dump, making it hard to follow a single install path.

## Design
One install flow plus a separate configuration reference. Align defaults with curvine Helm chart 0.3.2-alpha. Document OpenKruise as an optional advanced setting.

## Key Changes
- Rewrite `01-k8s-Deployment.md` (en + zh-cn)
- Remove formatMaster bootstrap steps from user-facing install flow
- Add concise OpenKruise capability notes