### PR TITLE
docs(csi): rewrite CSI driver Helm install and examples

### DIFF
--- a/docs/3-User-Manuals/5-K8S-CSI-Driver/01-Setup.md
+++ b/docs/3-User-Manuals/5-K8S-CSI-Driver/01-Setup.md
@@ -197,48 +197,126 @@ kubectl apply -f pod.yaml
 kubectl logs app-pod -n curvine
 ```
 
-## Mount Modes
-
-Default `node.mountMode=embedded`; see Deployment above.
-
-`standalone` install parameters:
-
-| Parameter | Description |
-|-----------|-------------|
-| `node.mountMode=standalone` | Enable standalone mode |
-| `node.standalone.resources.requests.cpu` | Standalone pod CPU request |
-| `node.standalone.resources.requests.memory` | Standalone pod memory request |
-| `node.standalone.resources.limits.cpu` | Standalone pod CPU limit |
-| `node.standalone.resources.limits.memory` | Standalone pod memory limit |
-| `node.standalone.image` | Standalone pod image; empty uses CSI image |
-
 ## Configuration Reference
 
-### Helm parameters
+Chart version `0.3.2-alpha`. Defaults below match `helm show values curvine/curvine-csi --version 0.3.2-alpha`.
 
-| Parameter | Default |
-|-----------|---------|
-| `node.mountMode` | `embedded` |
-| `csiDriver.name` | `curvine` |
-| `image.repository` | `ghcr.io/curvineio/curvine-csi` |
+### Image
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `image.repository` | `ghcr.io/curvineio/curvine-csi` | CSI image repository |
+| `image.tag` | `""` | Empty uses `v{Chart.AppVersion}` |
+| `image.pullPolicy` | `Always` | Image pull policy |
+
+### CSI driver
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `csiDriver.name` | `curvine` | CSI driver name |
+| `csiDriver.attachRequired` | `false` | Attach operation not required |
+| `csiDriver.podInfoOnMount` | `false` | Pod info not required on mount |
+
+### Controller
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `controller.name` | `curvine-csi-controller` | Deployment name |
+| `controller.replicas` | `1` | Controller replicas |
+| `controller.priorityClassName` | `system-cluster-critical` | Priority class |
+| `controller.container.name` | `csi-plugin` | Main container name |
+| `controller.container.env.CSI_ENDPOINT` | `unix:///csi/csi.sock` | CSI socket |
+| `controller.container.ports.healthz` | `9909` | Health check port |
+| `controller.container.securityContext.privileged` | `true` | Privileged mode |
+| `controller.sidecars.provisioner.image` | `quay.io/k8scsi/csi-provisioner:v1.6.0` | Provisioner sidecar |
+| `controller.sidecars.attacher.image` | `registry.k8s.io/sig-storage/csi-attacher:v4.5.0` | Attacher sidecar |
+| `controller.sidecars.livenessProbe.image` | `registry.k8s.io/sig-storage/livenessprobe:v2.11.0` | Liveness probe sidecar |
+
+If provisioner or registrar sidecars fail with `ImagePullBackOff`, override with `registry.k8s.io/sig-storage` images:
+
+```bash
+--set controller.sidecars.provisioner.image=registry.k8s.io/sig-storage/csi-provisioner:v5.0.1 \
+--set node.sidecars.nodeDriverRegistrar.image=registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0
+```
+
+### Node
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `node.name` | `curvine-csi-node` | DaemonSet name |
+| `node.priorityClassName` | `system-node-critical` | Priority class |
+| `node.dnsPolicy` | `ClusterFirstWithHostNet` | DNS policy |
+| `node.fuseDebugEnabled` | `false` | FUSE debug logging |
+| `node.mountMode` | `embedded` | `embedded` or `standalone` |
+| `node.container.name` | `csi-plugin` | Main container name |
+| `node.container.env.CSI_ENDPOINT` | `unix:///csi/csi.sock` | CSI socket |
+| `node.container.ports.healthz` | `9909` | Health check port |
+| `node.container.ports.metrics` | `9002` | Metrics port |
+| `node.container.securityContext.privileged` | `true` | Privileged mode |
+| `node.container.resources.requests.cpu` | `500m` | CPU request (`embedded` mode) |
+| `node.container.resources.requests.memory` | `512Mi` | Memory request (`embedded` mode) |
+| `node.container.resources.limits.cpu` | `2` | CPU limit (`embedded` mode) |
+| `node.container.resources.limits.memory` | `2Gi` | Memory limit (`embedded` mode) |
+| `node.sidecars.nodeDriverRegistrar.image` | `quay.io/k8scsi/csi-node-driver-registrar:v2.1.0` | Registrar sidecar |
+| `node.sidecars.livenessProbe.image` | `registry.k8s.io/sig-storage/livenessprobe:v2.11.0` | Liveness probe sidecar |
+| `node.hostPaths.pluginDir.path` | `/var/lib/kubelet/csi-plugins/csi.curvine.io/` | CSI plugin directory |
+| `node.hostPaths.kubeletDir.path` | `/var/lib/kubelet` | Kubelet directory |
+| `node.hostPaths.registrationDir.path` | `/var/lib/kubelet/plugins_registry/` | Plugin registration directory |
+
+### Standalone mount mode (`node.mountMode=standalone`)
+
+FUSE runs in a separate pod. Use when FUSE must survive CSI node pod restarts.
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `node.standalone.image` | `""` | Standalone pod image; empty uses CSI image |
+| `node.standalone.resources.requests.cpu` | `500m` | CPU request |
+| `node.standalone.resources.requests.memory` | `512Mi` | Memory request |
+| `node.standalone.resources.limits.cpu` | `2` | CPU limit |
+| `node.standalone.resources.limits.memory` | `2Gi` | Memory limit |
+
+### Service account and RBAC
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `serviceAccount.controller.name` | `""` | Auto-derived from release name when empty |
+| `serviceAccount.node.name` | `""` | Auto-derived from release name when empty |
+| `rbac.create` | `true` | Create RBAC resources |
+
+### Curvine volume parameters
+
+Used in StorageClass `parameters` (dynamic PV) or PV `csi.volumeAttributes` (static PV).
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `master-addrs` | Yes | — | Curvine master addresses, `host:port` comma-separated |
+| `fs-path` | Dynamic PV | `/` | Path prefix; actual path is `fs-path` + `/` + pv-name |
+| `curvine-path` | Static PV | — | Full path in Curvine filesystem |
+| `path-type` | No | `Directory` | `Directory` or `DirectoryOrCreate` |
+
+Additional keys (for example `io-threads`, `worker-threads`) are forwarded to `curvine-fuse` as CLI flags. The following keys are reserved and must not be set manually: `master-addrs`, `fs-path`, `path-type`, `curvine-path`, `mnt-path`.
+
+### Examples
+
+Override embedded mode resources:
+
+```bash
+helm upgrade curvine-csi curvine/curvine-csi -n curvine-system --reuse-values \
+  --set node.container.resources.requests.cpu=200m \
+  --set node.container.resources.requests.memory=256Mi
+```
+
+Full parameter list:
 
 ```bash
 helm show values curvine/curvine-csi --version 0.3.2-alpha
 ```
-
-### Curvine volume parameters
-
-| Parameter | Required | Description |
-|-----------|----------|-------------|
-| `master-addrs` | Yes | `host:port`, comma-separated |
-| `fs-path` | Dynamic provisioning | Path prefix |
-| `curvine-path` | Static PV | Full path |
-| `path-type` | No | `DirectoryOrCreate` or `Directory` |
 
 ## Troubleshooting
 
 | Symptom | Action |
 |---------|--------|
 | CSI pod unhealthy | `kubectl logs -n curvine-system -l app=curvine-csi-node -c csi-plugin` |
+| Sidecar ImagePullBackOff | Override sidecar images; see Configuration Reference |
 | `master-addrs` unreachable | `kubectl get pods -n curvine` |
 | Mount disconnected | Restart the application pod |

--- a/docs/3-User-Manuals/5-K8S-CSI-Driver/01-Setup.md
+++ b/docs/3-User-Manuals/5-K8S-CSI-Driver/01-Setup.md
@@ -1,332 +1,58 @@
-# Installation Guide
-To facilitate quick integration with Curvine in cloud-native environments, Curvine provides CSI driver support. Your Pod containers can access Curvine through `PV` (Persistent Volume) without requiring application modifications, enabling seamless use of Curvine's caching capabilities.
+# K8S CSI Driver
 
-The Curvine CSI driver follows the standard CSI specification and includes:
-- `CSI Controller`, deployed in `Deployment` or `Statefulset` mode
-- `CSI Node Plugin`, deployed in `DaemonSet` mode
+Prerequisite: curvine cluster installed via Helm in namespace `curvine`.
 
-## Architecture Overview
+Chart: `curvine/curvine-csi`, version `0.3.2-alpha`. Release namespace: `curvine-system`.
 
-The Curvine CSI driver adopts the standard CSI architecture with two main components:
+## Architecture
 
-```mermaid
-%%{init: {'theme': 'base', 'themeVariables': { 'background': '#ffffff', 'primaryColor': '#4a9eff', 'primaryTextColor': '#1a202c', 'primaryBorderColor': '#3182ce', 'lineColor': '#4a5568', 'secondaryColor': '#805ad5', 'tertiaryColor': '#38a169', 'mainBkg': '#ffffff', 'nodeBorder': '#4a5568', 'clusterBkg': '#f8f9fa', 'clusterBorder': '#dee2e6', 'titleColor': '#1a202c'}}}%%
-graph TB
-    subgraph "Kubernetes Cluster"
-        subgraph "Control Plane"
-            Controller[CSI Controller<br/>Deployment]
-            Provisioner[csi-provisioner]
-            Attacher[csi-attacher]
-            Controller --> Provisioner
-            Controller --> Attacher
-        end
-        
-        subgraph "Worker Nodes"
-            Node1[CSI Node Plugin<br/>DaemonSet]
-            Node2[CSI Node Plugin<br/>DaemonSet]
-            Registrar1[node-driver-registrar]
-            Registrar2[node-driver-registrar]
-            Node1 --> Registrar1
-            Node2 --> Registrar2
-        end
-        
-        Pod1[Application Pod]
-        Pod2[Application Pod]
-        
-        Pod1 -.Mount.-> Node1
-        Pod2 -.Mount.-> Node2
-    end
-    
-    subgraph "Curvine Cluster"
-        Master[Master Nodes<br/>8995]
-        Storage[Storage Nodes]
-        Master --> Storage
-    end
-    
-    Node1 -.FUSE Mount.-> Master
-    Node2 -.FUSE Mount.-> Master
+| Component | Type | Description |
+|-----------|------|-------------|
+| CSI Controller | Deployment | Volume create and delete |
+| CSI Node | DaemonSet | Node mount |
 
-    %% Styles - colors adjusted for light background
-    classDef csiStyle fill:#4a9eff,stroke:#2b6cb0,color:#fff,stroke-width:2px
-    classDef sidecarStyle fill:#805ad5,stroke:#553c9a,color:#fff,stroke-width:2px
-    classDef nodeStyle fill:#48bb78,stroke:#276749,color:#fff,stroke-width:2px
-    classDef appStyle fill:#ed8936,stroke:#c05621,color:#fff,stroke-width:2px
-    classDef storageStyle fill:#fc8181,stroke:#c53030,color:#1a202c,stroke-width:2px
-    
-    class Controller,Node1,Node2 csiStyle
-    class Provisioner,Attacher,Registrar1,Registrar2 sidecarStyle
-    class Pod1,Pod2 appStyle
-    class Master,Storage storageStyle
-```
+Default `node.mountMode=embedded`. In `standalone` mode, FUSE runs in a separate pod.
 
-### Core Components
-
-1. **CSI Controller**
-   - Runs in the Control Plane
-   - Responsible for Volume creation, deletion, Attach/Detach operations
-   - Includes csi-provisioner and csi-attacher sidecars
-
-2. **CSI Node Plugin**
-   - Runs as DaemonSet on each Worker Node
-   - Responsible for mounting Curvine storage to Pods
-   - Uses FUSE technology for filesystem mounting
-
-3. **FUSE Mounting Mechanism**
-   - Directly mounts Curvine filesystem paths
-   - Same paths share FUSE process, saving resources
-   - Supports concurrent access by multiple Pods
-
----
-
-## Prerequisites
-
-### Environment Requirements
-
-- Kubernetes 1.19+
-- Helm 3.0+
-- Accessible Curvine cluster (Master node address and port)
-- Cluster administrator privileges
-
-### Environment Check
-
-```bash
-# Check Kubernetes version
-kubectl version --short
-
-# Check Helm version
-helm version --short
-
-# Check node status
-kubectl get nodes
-```
-
----
-
-## I. Installing Curvine CSI
-
-### 1.1 Get Helm Chart
+## Deployment
 
 ```bash
 helm repo add curvine https://curvineio.github.io/helm-charts
 helm repo update
-helm search repo curvine --devel
-helm install curvine-csi curvine/curvine-csi \ 
-    --namespace curvine \ 
-    --create-namespace --devel \ 
-    --version 0.0.1-dev+7ffc6a2
-```
 
+helm upgrade --install curvine-csi curvine/curvine-csi \
+  --version 0.3.2-alpha \
+  -n curvine-system \
+  --create-namespace \
+  --wait --timeout 8m
 
-:::tip
-The current Curvine Helm repository provides pre-release versions:
-- Use `--devel` to view them, and replace the `--version` in the command above with your desired version
-- curvine-csi is installed by default in the `curvine` namespace via Helm
-- Official release versions will be provided progressively
-:::
-
-### 1.2 Configure Custom Parameters (Optional)
-curvine-csi supports rich customization parameters. If your network environment has restrictions, you can use custom images and other methods.
-
-For example, create a `custom-values.yaml` file:
-
-```yaml
-# Image configuration
-image:
-  repository: ghcr.io/curvineio/curvine-csi
-  tag: latest
-  pullPolicy: IfNotPresent
-
-# Controller configuration
-controller:
-  replicas: 1
-  resources:
-    requests:
-      cpu: 100m
-      memory: 128Mi
-    limits:
-      cpu: 500m
-      memory: 512Mi
-
-# Node configuration - Embedded mode (default)
-node:
-  mountMode: embedded
-  container:
-    resources:
-      requests:
-        cpu: 500m
-        memory: 512Mi
-      limits:
-        cpu: 2
-        memory: 2Gi
-```
-
-Or use Standalone mode for FUSE lifecycle isolation:
-
-```yaml
-# Node configuration - Standalone mode (optional)
-node:
-  mountMode: standalone
-  standalone:
-    image: ""
-    resources:
-      requests:
-        cpu: 500m
-        memory: 512Mi
-      limits:
-        cpu: 2
-        memory: 2Gi
-```
-
-Install with custom parameters using Helm:
-```bash
-helm install curvine-csi curvine/curvine-csi \ 
-    --namespace curvine \ 
-    --create-namespace --devel \ 
-  --values custom-values.yaml
-
-# Check installation status
-helm status curvine-csi -n curvine
-```
-
-:::tip
-By default, the Helm chart uses `embedded` mode, where FUSE runs inside the CSI node container for simpler deployment. Use `standalone` mode when FUSE must survive CSI node pod restarts or upgrades. For architecture details and Helm configuration parameters, refer to [Curvine CSI Architecture](Framework).
-:::
-
-### 1.4 Upgrade and Uninstall
-
-```bash
-# Upgrade
-helm upgrade curvine curvine/curvine-csi -n curvine --devel --version xxxxx
-
-# Uninstall
-helm uninstall curvine-csi -n curvine
-
-# Complete cleanup (including namespace)
-kubectl delete namespace curvine
-```
-
----
-
-## II. Verification and Status Check
-
-### 2.1 Check CSI Driver Registration
-
-```bash
-# Check if CSI Driver is registered successfully
 kubectl get csidriver curvine
-
-# Example output:
-# NAME      ATTACHREQUIRED   PODINFOONMOUNT   STORAGECAPACITY
-# curvine   false            false            false
+kubectl get pods -n curvine-system
 ```
 
-**Parameter Explanation:**
-- `ATTACHREQUIRED: false` - No Attach operation needed (direct FUSE mount)
-- `PODINFOONMOUNT: false` - No Pod information needed during mount
-
-### 2.2 Check Controller Status
+`standalone` mount mode:
 
 ```bash
-# Check Controller Deployment
-kubectl get deployment -n curvine curvine-csi-controller
-
-# Check Controller Pod
-kubectl get pods -n curvine -l app=curvine-csi-controller
-
-# Check Controller logs
-kubectl logs -n curvine \
-  -l app=curvine-csi-controller \
-  -c csi-plugin \
-  --tail=50
-
-# Check Provisioner Sidecar logs
-kubectl logs -n curvine \
-  -l app=curvine-csi-controller \
-  -c csi-provisioner \
-  --tail=50
+helm upgrade --install curvine-csi curvine/curvine-csi \
+  --version 0.3.2-alpha \
+  -n curvine-system \
+  --create-namespace \
+  --set node.mountMode=standalone \
+  --set node.standalone.resources.requests.cpu=500m \
+  --set node.standalone.resources.requests.memory=512Mi \
+  --set node.standalone.resources.limits.cpu=2 \
+  --set node.standalone.resources.limits.memory=2Gi \
+  --wait --timeout 8m
 ```
 
-### 2.3 Check Node Plugin Status
+## Example 1: Dynamic PV
 
-```bash
-# Check Node DaemonSet
-kubectl get daemonset -n curvine curvine-csi-node
+`master-addrs` below is for a single-replica curvine cluster. For three replicas:
 
-# Check all Node Plugin Pods
-kubectl get pods -n curvine -l app=curvine-csi-node -o wide
-
-# Check specific Node logs
-kubectl logs -n curvine curvine-csi-node-xxxxx -c csi-plugin
-
-# Check Node Registrar logs
-kubectl logs -n curvine curvine-csi-node-xxxxx -c node-driver-registrar
+```text
+curvine-master-0.curvine-master.curvine.svc.cluster.local:8995,curvine-master-1.curvine-master.curvine.svc.cluster.local:8995,curvine-master-2.curvine-master.curvine.svc.cluster.local:8995
 ```
 
-## III. StorageClass Explained
-
-StorageClass is a resource in Kubernetes that defines storage types, used for automatic creation of dynamic PVs.
-
-### 3.1 StorageClass Configuration Example
-
-```yaml
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: curvine-sc
-provisioner: curvine                      # CSI driver name
-reclaimPolicy: Delete                     # Reclaim policy
-volumeBindingMode: Immediate              # Binding mode
-allowVolumeExpansion: true                # Allow expansion
-parameters:
-  # Required: Curvine cluster connection information
-  master-addrs: "master1:8995,master2:8995,master3:8995"
-  
-  # Required: Filesystem path prefix
-  fs-path: "/k8s-volumes"
-  
-  # Optional: Path creation strategy
-  path-type: "DirectoryOrCreate"
-  
-  # Optional: FUSE parameters
-  io-threads: "4"
-  worker-threads: "8"
-```
-
-### 3.2 Parameter Details
-
-#### Core Parameters
-
-| Parameter | Required | Description | Example |
-|-----|------|------|------|
-| `master-addrs` | ✅ | Curvine Master node address list, comma-separated | `"10.0.0.1:8995,10.0.0.2:8995"` |
-| `fs-path` | ✅ | Path prefix for dynamic PVs, actual path is `fs-path + pv-name` | `"/k8s-volumes"` |
-| `path-type` | ❌ | Path creation strategy, defaults to `Directory` | `"DirectoryOrCreate"`(Automatically creates path if it doesn't exist); `"Directory"`(Path must already exist) |
-| `reclaimPolicy` | ❌ | PV reclaim policy, defaults to `Delete` | `"Delete"`(Automatically deletes PV and storage data when PVC is deleted); `"Retain"`(PV is retained after PVC deletion) |
-| `Binding Mode` | ❌ | PV binding mode, defaults to `Immediate` | `"Immediate"`(PV is bound immediately after PVC creation); `"WaitForFirstConsumer"`(Waits for Pod scheduling before binding PV) |
-| `io-threads` | ❌ | FUSE IO thread count | `"4"` |
-| `worker-threads` | ❌ | FUSE worker thread count | `"8"` |
-
-### 3.3 Dynamic PV Path Generation Rules
-
-```
-Actual mount path = fs-path + "/" + pv-name
-```
-
-**Example:**
-```yaml
-# StorageClass configuration
-fs-path: "/k8s-volumes"
-
-# Auto-generated PV name
-pv-name: "pvc-1234-5678-abcd"
-
-# Final Curvine path
-Actual path: "/k8s-volumes/pvc-1234-5678-abcd"
-```
-
-### 3.4 Create StorageClass
-
-Create the `storageclass.yaml` file:
+### 1. StorageClass
 
 ```yaml
 apiVersion: storage.k8s.io/v1
@@ -338,494 +64,181 @@ reclaimPolicy: Delete
 volumeBindingMode: Immediate
 allowVolumeExpansion: true
 parameters:
-  master-addrs: "m0:8995,m1:8995,m2:8995"
+  master-addrs: "curvine-master-0.curvine-master.curvine.svc.cluster.local:8995"
   fs-path: "/k8s-volumes"
   path-type: "DirectoryOrCreate"
 ```
 
-Apply the configuration:
-
 ```bash
-# Create StorageClass
 kubectl apply -f storageclass.yaml
-
-# View StorageClass
-kubectl get storageclass curvine-sc
-
-# Set as default StorageClass (optional)
-kubectl patch storageclass curvine-sc \
-  -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
 ```
 
-:::tip
-Replace the `master-addrs` in the example above with your actual master addresses.
-:::
-
-### 3.5 Multiple StorageClass Scenarios
-
-You can create multiple StorageClasses for different scenarios:
+### 2. PVC
 
 ```yaml
-# Production environment - strict mode
----
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
+apiVersion: v1
+kind: PersistentVolumeClaim
 metadata:
-  name: curvine-prod
-provisioner: curvine
-reclaimPolicy: Retain
-volumeBindingMode: WaitForFirstConsumer
-parameters:
-  master-addrs: "prod-master1:8995,prod-master2:8995"
-  fs-path: "/production"
-  path-type: "Directory"
-
-# Development environment - relaxed mode
----
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: curvine-dev
-provisioner: curvine
-reclaimPolicy: Delete
-volumeBindingMode: Immediate
-parameters:
-  master-addrs: "dev-master:8995"
-  fs-path: "/development"
-  path-type: "DirectoryOrCreate"
+  name: app-data
+  namespace: curvine
+spec:
+  storageClassName: curvine-sc
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
 ```
 
----
-
-## IV. Static PV Usage
-
-Static PV is used to mount existing data directories in Curvine, suitable for the following scenarios:
-- Multiple clusters sharing the same data
-- Need for precise control over data paths
-
-### 4.1 Working Principle
-
-```mermaid
-%%{init: {'theme': 'base', 'themeVariables': { 'background': '#ffffff', 'primaryColor': '#4a9eff', 'primaryTextColor': '#1a202c', 'primaryBorderColor': '#3182ce', 'lineColor': '#4a5568', 'secondaryColor': '#805ad5', 'tertiaryColor': '#38a169', 'mainBkg': '#ffffff', 'nodeBorder': '#4a5568', 'clusterBkg': '#f8f9fa', 'clusterBorder': '#dee2e6', 'titleColor': '#1a202c'}}}%%
-flowchart LR
-    Start[Curvine cluster has existing data] --> CreatePV[Administrator creates PV<br/>specifying curvine-path]
-    CreatePV --> CreatePVC[User creates PVC<br/>binds to specified PV]
-    CreatePVC --> StandalonePod[Pod mounts PVC]
-    
-    %% Styles
-    classDef storageStyle fill:#fc8181,stroke:#c53030,color:#1a202c,stroke-width:2px
-    classDef adminStyle fill:#4a9eff,stroke:#2b6cb0,color:#fff,stroke-width:2px
-    classDef userStyle fill:#805ad5,stroke:#553c9a,color:#fff,stroke-width:2px
-    classDef appStyle fill:#ed8936,stroke:#c05621,color:#fff,stroke-width:2px
-    
-    class Start storageStyle
-    class CreatePV adminStyle
-    class CreatePVC userStyle
-    class StandalonePod appStyle
+```bash
+kubectl apply -f pvc.yaml
+kubectl wait --for=condition=Bound pvc/app-data -n curvine --timeout=120s
 ```
 
-### 4.2 Create Static PV
+### 3. Pod
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app-pod
+  namespace: curvine
+spec:
+  containers:
+    - name: app
+      image: busybox:1.36
+      command: ["sh", "-c", "echo test > /data/test.txt && cat /data/test.txt && sleep 3600"]
+      volumeMounts:
+        - name: data
+          mountPath: /data
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: app-data
+```
+
+```bash
+kubectl apply -f pod.yaml
+kubectl logs app-pod -n curvine
+```
+
+## Example 2: Static PV
+
+### 1. StorageClass
+
+Same as Example 1. Use the three-replica `master-addrs` when applicable.
+
+### 2. PV and PVC
 
 ```yaml
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: curvine-pv-existing-data
-  labels:
-    type: curvine-static
+  name: curvine-existing
 spec:
   storageClassName: curvine-sc
   capacity:
-    storage: 100Gi                    # Declared capacity
+    storage: 10Gi
   accessModes:
-    - ReadWriteMany                   # Supports multi-Pod read-write
-  persistentVolumeReclaimPolicy: Retain  # Retain data
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
   csi:
     driver: curvine
-    volumeHandle: "existing-data-volume-001"  # Unique identifier
+    volumeHandle: "existing-data-001"
     volumeAttributes:
-      # Required: Curvine Master address
-      master-addrs: "m0:8995,m1:8995,m2:8995"
-      
-      # Required: Complete path in Curvine
-      curvine-path: "/production/user-data"
-      
-      # Recommended: Use Directory to ensure path exists
+      master-addrs: "curvine-master-0.curvine-master.curvine.svc.cluster.local:8995"
+      curvine-path: "/existing-data"
       path-type: "Directory"
-      
-      # Optional: FUSE parameters
-      io-threads: "4"
-      worker-threads: "8"
-```
-
-**Parameter Explanation:**
-- `volumeHandle`: Any unique string, used to identify the PV
-- `curvine-path`: Complete path in Curvine filesystem, must already exist
-- `path-type: Directory`: Requires path to exist (recommended)
-
-### 4.3 Create Static PVC
-
-```yaml
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: curvine-pvc-existing-data
-  namespace: default
+  name: app-data
+  namespace: curvine
 spec:
   storageClassName: curvine-sc
   accessModes:
     - ReadWriteMany
   resources:
     requests:
-      storage: 100Gi
-  # Key: Specify the PV name to bind
-  volumeName: curvine-pv-existing-data
+      storage: 10Gi
+  volumeName: curvine-existing
 ```
-
-### 4.4 Verify Binding
 
 ```bash
-# Check PV status
-kubectl get pv curvine-pv-existing-data
-# STATUS should be Bound
-
-# Check PVC status
-kubectl get pvc curvine-pvc-existing-data
-# STATUS should be Bound
-
-# Check detailed information
-kubectl describe pvc curvine-pvc-existing-data
+kubectl apply -f pv-pvc.yaml
+kubectl wait --for=condition=Bound pvc/app-data -n curvine --timeout=120s
 ```
 
-### 4.5 Using Static PV in Pod
+### 3. Pod
 
 ```yaml
 apiVersion: v1
 kind: Pod
 metadata:
-  name: static-pv-test
+  name: app-pod
+  namespace: curvine
 spec:
   containers:
-  - name: app
-    image: nginx:alpine
-    volumeMounts:
-    - name: data
-      mountPath: /data
+    - name: app
+      image: busybox:1.36
+      command: ["sh", "-c", "echo test > /data/test.txt && cat /data/test.txt && sleep 3600"]
+      volumeMounts:
+        - name: data
+          mountPath: /data
   volumes:
-  - name: data
-    persistentVolumeClaim:
-      claimName: curvine-pvc-existing-data
-```
-
-## V. Dynamic PV Usage
-
-Dynamic PV is the most commonly used method, automatically created and managed by the CSI Controller.
-
-### 5.1 Working Principle
-
-```mermaid
-%%{init: {'theme': 'base', 'themeVariables': { 'background': '#ffffff', 'primaryColor': '#4a9eff', 'primaryTextColor': '#1a202c', 'primaryBorderColor': '#3182ce', 'lineColor': '#4a5568', 'secondaryColor': '#805ad5', 'tertiaryColor': '#38a169', 'mainBkg': '#ffffff', 'nodeBorder': '#4a5568', 'clusterBkg': '#f8f9fa', 'clusterBorder': '#dee2e6', 'titleColor': '#1a202c'}}}%%
-flowchart LR
-    CreatePVC[User creates PVC<br/>specifying StorageClass] --> AutoCreatePV[CSI Provisioner<br/>automatically creates PV]
-    AutoCreatePV --> GenPath[Auto-generates Curvine path<br/>fs-path + pv-name]
-    GenPath --> AutoBind[PVC automatically binds to PV]
-    AutoBind --> StandalonePod[Pod mounts PVC for use]
-    
-    %% Styles
-    classDef userStyle fill:#805ad5,stroke:#553c9a,color:#fff,stroke-width:2px
-    classDef csiStyle fill:#4a9eff,stroke:#2b6cb0,color:#fff,stroke-width:2px
-    classDef pathStyle fill:#48bb78,stroke:#276749,color:#fff,stroke-width:2px
-    classDef bindStyle fill:#ecc94b,stroke:#b7791f,color:#1a202c,stroke-width:2px
-    classDef appStyle fill:#ed8936,stroke:#c05621,color:#fff,stroke-width:2px
-    
-    class CreatePVC userStyle
-    class AutoCreatePV csiStyle
-    class GenPath pathStyle
-    class AutoBind bindStyle
-    class StandalonePod appStyle
-```
-
-### 5.2 Create Dynamic PVC
-
-Dynamic PVC requires specifying a storageclass, without specifying volumeName:
-
-```yaml
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: my-dynamic-pvc
-  namespace: default
-spec:
-  storageClassName: curvine-sc    # Specify StorageClass
-  accessModes:
-    - ReadWriteOnce               # or ReadWriteMany
-  resources:
-    requests:
-      storage: 10Gi               # Request capacity
-```
-
-### 5.3 Automatic Path Generation Example
-
-```yaml
-# StorageClass configuration
-fs-path: "/k8s-volumes"
-
-# PVC name
-name: my-dynamic-pvc
-
-# Auto-generated PV
-# volumeHandle: pvc-1a2b3c4d-5e6f-7g8h-9i0j-k1l2m3n4o5p6
-
-# Actual Curvine path
-# /k8s-volumes/pvc-1a2b3c4d-5e6f-7g8h-9i0j-k1l2m3n4o5p6
-
-# You can use Curvine's cv command to check if the volume was created correctly in the Curvine cluster
-./bin/cv fs ls /
-```
-
-### 5.4 Dynamic PV Complete Example
-
-Create the `dynamic-pvc.yaml` file:
-
-```yaml
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: app-data-pvc
-  namespace: default
-spec:
-  storageClassName: curvine-sc
-  accessModes:
-    - ReadWriteMany
-  resources:
-    requests:
-      storage: 20Gi
-```
-
-Create the `dynamic-pv-pod.yaml` file:
-
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: dynamic-pv-test
-spec:
-  containers:
-  - name: app
-    image: nginx:alpine
-    volumeMounts:
     - name: data
-      mountPath: /usr/share/nginx/html
-  volumes:
-  - name: data
-    persistentVolumeClaim:
-      claimName: app-data-pvc
+      persistentVolumeClaim:
+        claimName: app-data
 ```
-
-Apply the configuration:
 
 ```bash
-# 1. Create dynamic PVC
-kubectl apply -f dynamic-pvc.yaml
-
-# 2. Check PVC status (should automatically Bound)
-kubectl get pvc app-data-pvc
-kubectl describe pvc app-data-pvc
-
-# 3. Check auto-created PV
-kubectl get pv
-
-# 4. Create Pod using PVC
-kubectl apply -f dynamic-pv-pod.yaml
-
-# 5. Test write and read
-kubectl exec dynamic-pv-test -- sh -c 'echo "Hello Curvine" > /usr/share/nginx/html/index.html'
-kubectl exec dynamic-pv-test -- cat /usr/share/nginx/html/index.html
+kubectl apply -f pod.yaml
+kubectl logs app-pod -n curvine
 ```
 
+## Mount Modes
 
+Default `node.mountMode=embedded`; see Deployment above.
 
+`standalone` install parameters:
 
+| Parameter | Description |
+|-----------|-------------|
+| `node.mountMode=standalone` | Enable standalone mode |
+| `node.standalone.resources.requests.cpu` | Standalone pod CPU request |
+| `node.standalone.resources.requests.memory` | Standalone pod memory request |
+| `node.standalone.resources.limits.cpu` | Standalone pod CPU limit |
+| `node.standalone.resources.limits.memory` | Standalone pod memory limit |
+| `node.standalone.image` | Standalone pod image; empty uses CSI image |
 
-## Appendix
-### Helm Custom Parameters
-#### Global Settings
+## Configuration Reference
 
-| Parameter Path | Type | Default | Description |
-|---------|------|--------|------|
-| `global.namespace` | string | `curvine` | Namespace where CSI driver is deployed |
+### Helm parameters
 
-#### Image Settings
+| Parameter | Default |
+|-----------|---------|
+| `node.mountMode` | `embedded` |
+| `csiDriver.name` | `curvine` |
+| `image.repository` | `ghcr.io/curvineio/curvine-csi` |
 
-| Parameter Path | Type | Default | Description |
-|---------|------|--------|------|
-| `image.repository` | string | `ghcr.io/curvineio/curvine-csi` | CSI driver image repository address |
-| `image.tag` | string | `latest` | CSI driver image tag version |
-| `image.pullPolicy` | string | `Always` | Image pull policy (Always/IfNotPresent/Never) |
-
-#### CSI Driver Settings
-
-| Parameter Path | Type | Default | Description |
-|---------|------|--------|------|
-| `csiDriver.name` | string | `curvine` | CSI driver name identifier |
-| `csiDriver.attachRequired` | boolean | `false` | Whether attach operation is required (volume attachment to node) |
-| `csiDriver.podInfoOnMount` | boolean | `false` | Whether Pod information is required during mount |
-
-#### Controller Settings
-
-| Parameter Path | Type | Default | Description |
-|---------|------|--------|------|
-| `controller.name` | string | `curvine-csi-controller` | Controller Deployment name |
-| `controller.replicas` | int | `1` | Number of Controller replicas |
-| `controller.priorityClassName` | string | `system-cluster-critical` | Controller priority class name (high priority) |
-| `controller.container.name` | string | `csi-plugin` | Main container name |
-| `controller.container.command` | array | `["/opt/curvine/csi"]` | Container start command |
-| `controller.container.args` | array | See values.yaml | Container start arguments |
-| `controller.container.env.CSI_ENDPOINT` | string | `unix:///csi/csi.sock` | CSI socket endpoint address |
-| `controller.container.livenessProbe.failureThreshold` | int | `5` | Liveness probe failure threshold |
-| `controller.container.livenessProbe.httpGet.path` | string | `"/healthz"` | Liveness probe HTTP path |
-| `controller.container.livenessProbe.httpGet.port` | string | `healthz` | Liveness probe HTTP port name |
-| `controller.container.livenessProbe.initialDelaySeconds` | int | `10` | Liveness probe initial delay seconds |
-| `controller.container.livenessProbe.periodSeconds` | int | `10` | Liveness probe check period (seconds) |
-| `controller.container.livenessProbe.timeoutSeconds` | int | `3` | Liveness probe timeout (seconds) |
-| `controller.container.ports.healthz` | int | `9909` | Health check port |
-| `controller.container.securityContext.privileged` | boolean | `true` | Whether to run in privileged mode |
-| `controller.container.securityContext.capabilities.add` | array | `[SYS_ADMIN]` | Added Linux Capabilities |
-| `controller.tolerations` | array | See values.yaml | Pod toleration configuration (allows CriticalAddons scheduling) |
-
-#### Controller Sidecar Container Configuration
-
-| Parameter Path | Type | Default | Description |
-|---------|------|--------|------|
-| `controller.sidecars.provisioner.image` | string | `quay.io/k8scsi/csi-provisioner:v1.6.0` | Provisioner sidecar image |
-| `controller.sidecars.provisioner.args` | array | See values.yaml | Provisioner arguments (timeout 60s, log level v5) |
-| `controller.sidecars.attacher.image` | string | `registry.k8s.io/sig-storage/csi-attacher:v4.5.0` | Attacher sidecar image |
-| `controller.sidecars.attacher.args` | array | See values.yaml | Attacher arguments (log level v5) |
-| `controller.sidecars.livenessProbe.image` | string | `registry.k8s.io/sig-storage/livenessprobe:v2.11.0` | LivenessProbe sidecar image |
-| `controller.sidecars.livenessProbe.args` | array | See values.yaml | LivenessProbe arguments |
-| `controller.sidecars.livenessProbe.env.HEALTH_PORT` | string | `"9909"` | Health check port |
-
-#### Node Settings
-
-| Parameter Path | Type | Default | Description |
-|---------|------|--------|------|
-| `node.name` | string | `curvine-csi-node` | Node DaemonSet name |
-| `node.priorityClassName` | string | `system-node-critical` | Node priority class name (node critical level) |
-| `node.dnsPolicy` | string | `ClusterFirstWithHostNet` | DNS policy (cluster first + host network) |
-| `node.fuseDebugEnabled` | boolean | `false` | Enable FUSE debug mode (sets FUSE_DEBUG_ENABLED env) |
-| `node.mountMode` | string | `embedded` | Mount mode: `embedded` (FUSE in CSI container, default) or `standalone` (independent FUSE pod) |
-| `node.container.name` | string | `csi-plugin` | Main container name |
-| `node.container.command` | array | `["/opt/curvine/csi"]` | Container start command |
-| `node.container.args` | array | See values.yaml | Container start arguments |
-| `node.container.env.CSI_ENDPOINT` | string | `unix:///csi/csi.sock` | CSI socket endpoint address |
-| `node.container.livenessProbe.failureThreshold` | int | `5` | Liveness probe failure threshold |
-| `node.container.livenessProbe.httpGet.path` | string | `"/healthz"` | Liveness probe HTTP path |
-| `node.container.livenessProbe.httpGet.port` | string | `healthz` | Liveness probe HTTP port name |
-| `node.container.livenessProbe.initialDelaySeconds` | int | `10` | Liveness probe initial delay seconds |
-| `node.container.livenessProbe.periodSeconds` | int | `10` | Liveness probe check period (seconds) |
-| `node.container.livenessProbe.timeoutSeconds` | int | `3` | Liveness probe timeout (seconds) |
-| `node.container.ports.healthz` | int | `9909` | Health check port |
-| `node.container.securityContext.privileged` | boolean | `true` | Whether to run in privileged mode |
-| `node.container.lifecycle.preStop` | object | See values.yaml | Container pre-stop hook (cleanup socket files) |
-| `node.tolerations` | array | `[{operator: Exists}]` | Pod toleration configuration (tolerates all taints) |
-
-#### Embedded Mode Settings
-
-When `node.mountMode` is `embedded` (default), resource limits apply to the CSI node container:
-
-| Parameter Path | Type | Default | Description |
-|---------|------|--------|------|
-| `node.container.resources.requests.cpu` | string | `"500m"` | CPU request |
-| `node.container.resources.requests.memory` | string | `"512Mi"` | Memory request |
-| `node.container.resources.limits.cpu` | string | `"2"` | CPU limit |
-| `node.container.resources.limits.memory` | string | `"2Gi"` | Memory limit |
-
-Example configuration:
-
-```yaml
-node:
-  mountMode: embedded
-  container:
-    resources:
-      requests:
-        cpu: "500m"
-        memory: "512Mi"
-      limits:
-        cpu: "2"
-        memory: "2Gi"
+```bash
+helm show values curvine/curvine-csi --version 0.3.2-alpha
 ```
 
-#### Standalone Pod Settings
+### Curvine volume parameters
 
-When `node.mountMode` is set to `standalone`, the following settings apply:
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `master-addrs` | Yes | `host:port`, comma-separated |
+| `fs-path` | Dynamic provisioning | Path prefix |
+| `curvine-path` | Static PV | Full path |
+| `path-type` | No | `DirectoryOrCreate` or `Directory` |
 
-| Parameter Path | Type | Default | Description |
-|---------|------|--------|------|
-| `node.standalone.image` | string | `""` | Standalone Pod image, empty uses CSI image |
-| `node.standalone.resources.requests.cpu` | string | `"500m"` | CPU request |
-| `node.standalone.resources.requests.memory` | string | `"512Mi"` | Memory request |
-| `node.standalone.resources.limits.cpu` | string | `"2"` | CPU limit |
-| `node.standalone.resources.limits.memory` | string | `"2Gi"` | Memory limit |
+## Troubleshooting
 
-Example configuration:
-
-```yaml
-node:
-  mountMode: standalone
-  standalone:
-    image: ""  # Empty uses CSI image
-    resources:
-      requests:
-        cpu: "500m"
-        memory: "512Mi"
-      limits:
-        cpu: "2"
-        memory: "2Gi"
-```
-
-#### Node Sidecar Container Configuration
-
-| Parameter Path | Type | Default | Description |
-|---------|------|--------|------|
-| `node.sidecars.nodeDriverRegistrar.image` | string | `quay.io/k8scsi/csi-node-driver-registrar:v2.1.0` | Node driver registrar image |
-| `node.sidecars.nodeDriverRegistrar.args` | array | See values.yaml | Registrar arguments (log level v5) |
-| `node.sidecars.nodeDriverRegistrar.env.ADDRESS` | string | `/csi/csi.sock` | CSI socket address |
-| `node.sidecars.nodeDriverRegistrar.env.DRIVER_REG_SOCK_PATH` | string | `/var/lib/kubelet/csi-plugins/csi.curvine.io/csi.sock` | Driver registration path in Kubelet |
-| `node.sidecars.livenessProbe.image` | string | `registry.k8s.io/sig-storage/livenessprobe:v2.11.0` | LivenessProbe sidecar image |
-| `node.sidecars.livenessProbe.args` | array | See values.yaml | LivenessProbe arguments |
-| `node.sidecars.livenessProbe.env.ADDRESS` | string | `/csi/csi.sock` | CSI socket address |
-| `node.sidecars.livenessProbe.env.HEALTH_PORT` | string | `"9909"` | Health check port |
-
-#### Node Host Path Configuration
-
-| Parameter Path | Type | Default | Description |
-|---------|------|--------|------|
-| `node.hostPaths.pluginDir.path` | string | `/var/lib/kubelet/csi-plugins/csi.curvine.io/` | CSI plugin directory path |
-| `node.hostPaths.pluginDir.type` | string | `DirectoryOrCreate` | Path type (create if not exists) |
-| `node.hostPaths.kubeletDir.path` | string | `/var/lib/kubelet` | Kubelet working directory path |
-| `node.hostPaths.kubeletDir.type` | string | `DirectoryOrCreate` | Path type (create if not exists) |
-| `node.hostPaths.registrationDir.path` | string | `/var/lib/kubelet/plugins_registry/` | Plugin registration directory path |
-| `node.hostPaths.registrationDir.type` | string | `Directory` | Path type (must exist) |
-
-#### Service Account Settings
-
-| Parameter Path | Type | Default | Description |
-|---------|------|--------|------|
-| `serviceAccount.controller.name` | string | `curvine-csi-controller-sa` | Controller service account name |
-| `serviceAccount.node.name` | string | `curvine-csi-node-sa` | Node service account name |
-
-#### RBAC Configuration
-
-| Parameter Path | Type | Default | Description |
-|---------|------|--------|------|
-| `rbac.create` | boolean | `true` | Whether to create RBAC resources (ClusterRole/ClusterRoleBinding) |
-
-#### StorageClass Parameters (Configured at Usage Time)
-
-| Parameter Name | Required | Type | Default | Description |
-|--------|---------|------|--------|------|
-| `master-addrs` | **Required** | string | None | Curvine Master node addresses, format: `host:port,host:port` |
-| `fs-path` | **Required** | string | None | Filesystem path prefix, each PV creates: `fs-path + pv-name` |
-| `path-type` | Optional | string | `Directory` | Path creation strategy: `DirectoryOrCreate` or `Directory` |
-| `io-threads` | Optional | string | None | FUSE IO thread count |
-| `worker-threads` | Optional | string | None | FUSE worker thread count |
+| Symptom | Action |
+|---------|--------|
+| CSI pod unhealthy | `kubectl logs -n curvine-system -l app=curvine-csi-node -c csi-plugin` |
+| `master-addrs` unreachable | `kubectl get pods -n curvine` |
+| Mount disconnected | Restart the application pod |

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/3-User-Manuals/5-K8S-CSI-Driver/01-Setup.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/3-User-Manuals/5-K8S-CSI-Driver/01-Setup.md
@@ -197,48 +197,126 @@ kubectl apply -f pod.yaml
 kubectl logs app-pod -n curvine
 ```
 
-## 挂载模式
-
-默认 `node.mountMode=embedded`，安装命令见「部署」。
-
-`standalone` 模式安装参数：
-
-| 参数 | 说明 |
-|------|------|
-| `node.mountMode=standalone` | 启用 standalone |
-| `node.standalone.resources.requests.cpu` | Standalone Pod CPU request |
-| `node.standalone.resources.requests.memory` | Standalone Pod 内存 request |
-| `node.standalone.resources.limits.cpu` | Standalone Pod CPU limit |
-| `node.standalone.resources.limits.memory` | Standalone Pod 内存 limit |
-| `node.standalone.image` | Standalone Pod 镜像，空值使用 CSI 镜像 |
-
 ## 配置参考
 
-### Helm 参数
+Chart 版本 `0.3.2-alpha`。下表默认值与 `helm show values curvine/curvine-csi --version 0.3.2-alpha` 一致。
 
-| 参数 | 默认值 |
-|------|--------|
-| `node.mountMode` | `embedded` |
-| `csiDriver.name` | `curvine` |
-| `image.repository` | `ghcr.io/curvineio/curvine-csi` |
+### 镜像
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `image.repository` | `ghcr.io/curvineio/curvine-csi` | CSI 镜像仓库 |
+| `image.tag` | `""` | 空值使用 `v{Chart.AppVersion}` |
+| `image.pullPolicy` | `Always` | 镜像拉取策略 |
+
+### CSI 驱动
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `csiDriver.name` | `curvine` | CSI 驱动名称 |
+| `csiDriver.attachRequired` | `false` | 不需要 attach 操作 |
+| `csiDriver.podInfoOnMount` | `false` | 挂载时不需要 Pod 信息 |
+
+### Controller
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `controller.name` | `curvine-csi-controller` | Deployment 名称 |
+| `controller.replicas` | `1` | Controller 副本数 |
+| `controller.priorityClassName` | `system-cluster-critical` | 优先级类 |
+| `controller.container.name` | `csi-plugin` | 主容器名称 |
+| `controller.container.env.CSI_ENDPOINT` | `unix:///csi/csi.sock` | CSI 套接字 |
+| `controller.container.ports.healthz` | `9909` | 健康检查端口 |
+| `controller.container.securityContext.privileged` | `true` | 特权模式 |
+| `controller.sidecars.provisioner.image` | `quay.io/k8scsi/csi-provisioner:v1.6.0` | Provisioner sidecar |
+| `controller.sidecars.attacher.image` | `registry.k8s.io/sig-storage/csi-attacher:v4.5.0` | Attacher sidecar |
+| `controller.sidecars.livenessProbe.image` | `registry.k8s.io/sig-storage/livenessprobe:v2.11.0` | 存活探针 sidecar |
+
+若 provisioner 或 registrar sidecar 出现 `ImagePullBackOff`，可改用 `registry.k8s.io/sig-storage` 镜像：
+
+```bash
+--set controller.sidecars.provisioner.image=registry.k8s.io/sig-storage/csi-provisioner:v5.0.1 \
+--set node.sidecars.nodeDriverRegistrar.image=registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0
+```
+
+### Node
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `node.name` | `curvine-csi-node` | DaemonSet 名称 |
+| `node.priorityClassName` | `system-node-critical` | 优先级类 |
+| `node.dnsPolicy` | `ClusterFirstWithHostNet` | DNS 策略 |
+| `node.fuseDebugEnabled` | `false` | FUSE 调试日志 |
+| `node.mountMode` | `embedded` | `embedded` 或 `standalone` |
+| `node.container.name` | `csi-plugin` | 主容器名称 |
+| `node.container.env.CSI_ENDPOINT` | `unix:///csi/csi.sock` | CSI 套接字 |
+| `node.container.ports.healthz` | `9909` | 健康检查端口 |
+| `node.container.ports.metrics` | `9002` | 指标端口 |
+| `node.container.securityContext.privileged` | `true` | 特权模式 |
+| `node.container.resources.requests.cpu` | `500m` | CPU request（`embedded` 模式） |
+| `node.container.resources.requests.memory` | `512Mi` | 内存 request（`embedded` 模式） |
+| `node.container.resources.limits.cpu` | `2` | CPU limit（`embedded` 模式） |
+| `node.container.resources.limits.memory` | `2Gi` | 内存 limit（`embedded` 模式） |
+| `node.sidecars.nodeDriverRegistrar.image` | `quay.io/k8scsi/csi-node-driver-registrar:v2.1.0` | Registrar sidecar |
+| `node.sidecars.livenessProbe.image` | `registry.k8s.io/sig-storage/livenessprobe:v2.11.0` | 存活探针 sidecar |
+| `node.hostPaths.pluginDir.path` | `/var/lib/kubelet/csi-plugins/csi.curvine.io/` | CSI 插件目录 |
+| `node.hostPaths.kubeletDir.path` | `/var/lib/kubelet` | Kubelet 目录 |
+| `node.hostPaths.registrationDir.path` | `/var/lib/kubelet/plugins_registry/` | 插件注册目录 |
+
+### Standalone 挂载模式（`node.mountMode=standalone`）
+
+FUSE 运行在独立 Pod 中。适用于 CSI node Pod 重启后仍需保持 FUSE 挂载的场景。
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `node.standalone.image` | `""` | Standalone Pod 镜像，空值使用 CSI 镜像 |
+| `node.standalone.resources.requests.cpu` | `500m` | CPU request |
+| `node.standalone.resources.requests.memory` | `512Mi` | 内存 request |
+| `node.standalone.resources.limits.cpu` | `2` | CPU limit |
+| `node.standalone.resources.limits.memory` | `2Gi` | 内存 limit |
+
+### ServiceAccount 与 RBAC
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `serviceAccount.controller.name` | `""` | 空值由 release 名称派生 |
+| `serviceAccount.node.name` | `""` | 空值由 release 名称派生 |
+| `rbac.create` | `true` | 创建 RBAC 资源 |
+
+### Curvine 卷参数
+
+用于 StorageClass `parameters`（动态 PV）或 PV `csi.volumeAttributes`（静态 PV）。
+
+| 参数 | 必填 | 默认值 | 说明 |
+|------|------|--------|------|
+| `master-addrs` | 是 | — | Curvine master 地址，`host:port` 逗号分隔 |
+| `fs-path` | 动态 PV | `/` | 路径前缀；实际路径为 `fs-path` + `/` + pv-name |
+| `curvine-path` | 静态 PV | — | Curvine 文件系统中的完整路径 |
+| `path-type` | 否 | `Directory` | `Directory` 或 `DirectoryOrCreate` |
+
+其他键（如 `io-threads`、`worker-threads`）会透传给 `curvine-fuse` 作为 CLI 参数。以下键由驱动保留，不可手动设置：`master-addrs`、`fs-path`、`path-type`、`curvine-path`、`mnt-path`。
+
+### 示例
+
+覆盖 embedded 模式资源：
+
+```bash
+helm upgrade curvine-csi curvine/curvine-csi -n curvine-system --reuse-values \
+  --set node.container.resources.requests.cpu=200m \
+  --set node.container.resources.requests.memory=256Mi
+```
+
+完整参数：
 
 ```bash
 helm show values curvine/curvine-csi --version 0.3.2-alpha
 ```
-
-### Curvine 卷参数
-
-| 参数 | 必填 | 说明 |
-|------|------|------|
-| `master-addrs` | 是 | `host:port`，逗号分隔 |
-| `fs-path` | 动态供给 | 路径前缀 |
-| `curvine-path` | 静态卷 | 完整路径 |
-| `path-type` | 否 | `DirectoryOrCreate` 或 `Directory` |
 
 ## 故障排查
 
 | 现象 | 处理 |
 |------|------|
 | CSI Pod 异常 | `kubectl logs -n curvine-system -l app=curvine-csi-node -c csi-plugin` |
+| Sidecar ImagePullBackOff | 覆盖 sidecar 镜像，见「配置参考」 |
 | `master-addrs` 不可达 | `kubectl get pods -n curvine` |
 | 挂载断开 | 重启应用 Pod |

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/3-User-Manuals/5-K8S-CSI-Driver/01-Setup.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/3-User-Manuals/5-K8S-CSI-Driver/01-Setup.md
@@ -1,333 +1,58 @@
-# 安装指南
+# K8S CSI Driver
 
-为便于在云原生环境中快速接入 Curvine，Curvine 提供了 CSI 驱动支持。业务 Pod 可通过 `PV`（Persistent Volume）访问 Curvine 存储，无需修改应用代码，即可使用 Curvine 的缓存能力。
+前提：已通过 Helm 部署 curvine cluster（namespace `curvine`）。
 
-Curvine CSI 驱动遵循标准 CSI 规范，包含：
-- `CSI Controller`，以 `Deployment` 或 `StatefulSet` 方式部署
-- `CSI Node Plugin`，以 `DaemonSet` 方式部署
+Chart：`curvine/curvine-csi`，版本 `0.3.2-alpha`。Release namespace：`curvine-system`。
 
-## 架构概览
+## 架构说明
 
-Curvine CSI 驱动采用标准 CSI 架构，主要由两部分组成：
+| 组件 | 类型 | 说明 |
+|------|------|------|
+| CSI Controller | Deployment | 卷创建、删除 |
+| CSI Node | DaemonSet | 节点挂载 |
 
-```mermaid
-%%{init: {'theme': 'base', 'themeVariables': { 'background': '#ffffff', 'primaryColor': '#4a9eff', 'primaryTextColor': '#1a202c', 'primaryBorderColor': '#3182ce', 'lineColor': '#4a5568', 'secondaryColor': '#805ad5', 'tertiaryColor': '#38a169', 'mainBkg': '#ffffff', 'nodeBorder': '#4a5568', 'clusterBkg': '#f8f9fa', 'clusterBorder': '#dee2e6', 'titleColor': '#1a202c'}}}%%
-graph TB
-    subgraph "Kubernetes 集群"
-        subgraph "控制面"
-            Controller[CSI Controller<br/>Deployment]
-            Provisioner[csi-provisioner]
-            Attacher[csi-attacher]
-            Controller --> Provisioner
-            Controller --> Attacher
-        end
-        
-        subgraph "工作节点"
-            Node1[CSI Node Plugin<br/>DaemonSet]
-            Node2[CSI Node Plugin<br/>DaemonSet]
-            Registrar1[node-driver-registrar]
-            Registrar2[node-driver-registrar]
-            Node1 --> Registrar1
-            Node2 --> Registrar2
-        end
-        
-        Pod1[业务 Pod]
-        Pod2[业务 Pod]
-        
-        Pod1 -.挂载.-> Node1
-        Pod2 -.挂载.-> Node2
-    end
-    
-    subgraph "Curvine 集群"
-        Master[Master 节点<br/>8995]
-        Storage[存储节点]
-        Master --> Storage
-    end
-    
-    Node1 -.FUSE 挂载.-> Master
-    Node2 -.FUSE 挂载.-> Master
+默认 `node.mountMode=embedded`。`standalone` 模式下 FUSE 运行于独立 Pod。
 
-  classDef csiStyle fill:#4a9eff,stroke:#2b6cb0,color:#fff,stroke-width:2px
-  classDef sidecarStyle fill:#805ad5,stroke:#553c9a,color:#fff,stroke-width:2px
-  classDef nodeStyle fill:#48bb78,stroke:#276749,color:#fff,stroke-width:2px
-  classDef appStyle fill:#ed8936,stroke:#c05621,color:#fff,stroke-width:2px
-  classDef storageStyle fill:#fc8181,stroke:#c53030,color:#1a202c,stroke-width:2px
-  
-  class Controller,Node1,Node2 csiStyle
-  class Provisioner,Attacher,Registrar1,Registrar2 sidecarStyle
-  class Pod1,Pod2 appStyle
-  class Master,Storage storageStyle
-```
-
-### 核心组件
-
-1. **CSI Controller**
-   - 运行在控制面
-   - 负责卷的创建、删除以及 Attach/Detach 操作
-   - 包含 csi-provisioner 和 csi-attacher sidecar
-
-2. **CSI Node Plugin**
-   - 以 DaemonSet 方式运行在每个工作节点
-   - 负责将 Curvine 存储挂载到 Pod
-   - 通过 FUSE 技术实现文件系统挂载
-
-3. **FUSE 挂载机制**
-   - 直接挂载 Curvine 文件系统路径
-   - 相同路径共享 FUSE 进程，节省资源
-   - 支持多个 Pod 并发访问
-
----
-
-## 前置条件
-
-### 环境要求
-
-- Kubernetes 1.19+
-- Helm 3.0+
-- 可访问的 Curvine 集群（Master 节点地址和端口）
-- 集群管理员权限
-
-### 环境检查
-
-```bash
-# 检查 Kubernetes 版本
-kubectl version --short
-
-# 检查 Helm 版本
-helm version --short
-
-# 检查节点状态
-kubectl get nodes
-```
-
----
-
-## 一、安装 Curvine CSI
-
-### 1.1 获取 Helm Chart
+## 部署
 
 ```bash
 helm repo add curvine https://curvineio.github.io/helm-charts
 helm repo update
-helm search repo curvine --devel
-helm install curvine-csi curvine/curvine-csi \
-    --namespace curvine \
-    --create-namespace --devel \
-    --version 0.0.1-dev+7ffc6a2
-```
 
-:::tip
-当前 Curvine Helm 仓库提供预发布版本：
-- 使用 `--devel` 查看可用版本，并将上面命令中的 `--version` 替换为目标版本
-- 通过 Helm 安装时，curvine-csi 默认部署在 `curvine` 命名空间
-- 正式 release 版本会逐步提供
-:::
+helm upgrade --install curvine-csi curvine/curvine-csi \
+  --version 0.3.2-alpha \
+  -n curvine-system \
+  --create-namespace \
+  --wait --timeout 8m
 
-### 1.2 配置自定义参数（可选）
-
-curvine-csi 支持丰富的自定义参数。若网络环境受限，可自定义镜像等配置。
-
-例如，创建 `custom-values.yaml` 文件：
-
-```yaml
-# 镜像配置
-image:
-  repository: ghcr.io/curvineio/curvine-csi
-  tag: latest
-  pullPolicy: IfNotPresent
-
-# Controller 配置
-controller:
-  replicas: 1
-  resources:
-    requests:
-      cpu: 100m
-      memory: 128Mi
-    limits:
-      cpu: 500m
-      memory: 512Mi
-
-# Node 配置 - Embedded 模式（默认）
-node:
-  mountMode: embedded
-  container:
-    resources:
-      requests:
-        cpu: 500m
-        memory: 512Mi
-      limits:
-        cpu: 2
-        memory: 2Gi
-```
-
-如需 FUSE 生命周期隔离，可使用 Standalone 模式：
-
-```yaml
-# Node 配置 - Standalone 模式（可选）
-node:
-  mountMode: standalone
-  standalone:
-    image: ""
-    resources:
-      requests:
-        cpu: 500m
-        memory: 512Mi
-      limits:
-        cpu: 2
-        memory: 2Gi
-```
-
-使用自定义参数安装：
-
-```bash
-helm install curvine-csi curvine/curvine-csi \
-    --namespace curvine \
-    --create-namespace --devel \
-  --values custom-values.yaml
-
-# 检查安装状态
-helm status curvine-csi -n curvine
-```
-
-:::tip
-Helm Chart 默认使用 `embedded` 模式，FUSE 运行在 CSI node 容器内，部署更简单。若需要 FUSE 在 CSI node Pod 重启或升级后仍能存活，请使用 `standalone` 模式。架构细节和 Helm 参数说明见 [Curvine CSI 架构](04-Framework.md)。
-:::
-
-### 1.4 升级与卸载
-
-```bash
-# 升级
-helm upgrade curvine curvine/curvine-csi -n curvine --devel --version xxxxx
-
-# 卸载
-helm uninstall curvine-csi -n curvine
-
-# 完整清理（包括命名空间）
-kubectl delete namespace curvine
-```
-
----
-
-## 二、验证与状态检查
-
-### 2.1 检查 CSI 驱动注册
-
-```bash
-# 检查 CSI Driver 是否注册成功
 kubectl get csidriver curvine
-
-# 示例输出：
-# NAME      ATTACHREQUIRED   PODINFOONMOUNT   STORAGECAPACITY
-# curvine   false            false            false
+kubectl get pods -n curvine-system
 ```
 
-**参数说明：**
-- `ATTACHREQUIRED: false` — 无需 Attach 操作（直接 FUSE 挂载）
-- `PODINFOONMOUNT: false` — 挂载时不需要 Pod 信息
-
-### 2.2 检查 Controller 状态
+`standalone` 挂载模式：
 
 ```bash
-# 检查 Controller Deployment
-kubectl get deployment -n curvine curvine-csi-controller
-
-# 检查 Controller Pod
-kubectl get pods -n curvine -l app=curvine-csi-controller
-
-# 检查 Controller 日志
-kubectl logs -n curvine \
-  -l app=curvine-csi-controller \
-  -c csi-plugin \
-  --tail=50
-
-# 检查 Provisioner Sidecar 日志
-kubectl logs -n curvine \
-  -l app=curvine-csi-controller \
-  -c csi-provisioner \
-  --tail=50
+helm upgrade --install curvine-csi curvine/curvine-csi \
+  --version 0.3.2-alpha \
+  -n curvine-system \
+  --create-namespace \
+  --set node.mountMode=standalone \
+  --set node.standalone.resources.requests.cpu=500m \
+  --set node.standalone.resources.requests.memory=512Mi \
+  --set node.standalone.resources.limits.cpu=2 \
+  --set node.standalone.resources.limits.memory=2Gi \
+  --wait --timeout 8m
 ```
 
-### 2.3 检查 Node Plugin 状态
+## 示例一：动态 PV
 
-```bash
-# 检查 Node DaemonSet
-kubectl get daemonset -n curvine curvine-csi-node
+以下 `master-addrs` 按单副本 curvine cluster 编写。三副本时改为：
 
-# 检查所有 Node Plugin Pod
-kubectl get pods -n curvine -l app=curvine-csi-node -o wide
-
-# 检查指定 Node 日志
-kubectl logs -n curvine curvine-csi-node-xxxxx -c csi-plugin
-
-# 检查 Node Registrar 日志
-kubectl logs -n curvine curvine-csi-node-xxxxx -c node-driver-registrar
+```text
+curvine-master-0.curvine-master.curvine.svc.cluster.local:8995,curvine-master-1.curvine-master.curvine.svc.cluster.local:8995,curvine-master-2.curvine-master.curvine.svc.cluster.local:8995
 ```
 
-## 三、StorageClass 说明
-
-StorageClass 是 Kubernetes 中定义存储类型的资源，用于自动创建动态 PV。
-
-### 3.1 StorageClass 配置示例
-
-```yaml
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: curvine-sc
-provisioner: curvine                      # CSI 驱动名称
-reclaimPolicy: Delete                     # 回收策略
-volumeBindingMode: Immediate              # 绑定模式
-allowVolumeExpansion: true                # 允许扩容
-parameters:
-  # 必填：Curvine 集群连接信息
-  master-addrs: "master1:8995,master2:8995,master3:8995"
-  
-  # 必填：文件系统路径前缀
-  fs-path: "/k8s-volumes"
-  
-  # 可选：路径创建策略
-  path-type: "DirectoryOrCreate"
-  
-  # 可选：FUSE 参数
-  io-threads: "4"
-  worker-threads: "8"
-```
-
-### 3.2 参数说明
-
-#### 核心参数
-
-| 参数 | 必填 | 说明 | 示例 |
-|-----|------|------|------|
-| `master-addrs` | ✅ | Curvine Master 节点地址列表，逗号分隔 | `"10.0.0.1:8995,10.0.0.2:8995"` |
-| `fs-path` | ✅ | 动态 PV 的路径前缀，实际路径为 `fs-path + pv-name` | `"/k8s-volumes"` |
-| `path-type` | ❌ | 路径创建策略，默认 `Directory` | `"DirectoryOrCreate"`（路径不存在时自动创建）；`"Directory"`（路径必须已存在） |
-| `reclaimPolicy` | ❌ | PV 回收策略，默认 `Delete` | `"Delete"`（删除 PVC 时自动删除 PV 和存储数据）；`"Retain"`（删除 PVC 后保留 PV） |
-| `Binding Mode` | ❌ | PV 绑定模式，默认 `Immediate` | `"Immediate"`（创建 PVC 后立即绑定 PV）；`"WaitForFirstConsumer"`（等待 Pod 调度后再绑定 PV） |
-| `io-threads` | ❌ | FUSE IO 线程数 | `"4"` |
-| `worker-threads` | ❌ | FUSE 工作线程数 | `"8"` |
-
-### 3.3 动态 PV 路径生成规则
-
-```
-实际挂载路径 = fs-path + "/" + pv-name
-```
-
-**示例：**
-```yaml
-# StorageClass 配置
-fs-path: "/k8s-volumes"
-
-# 自动生成的 PV 名称
-pv-name: "pvc-1234-5678-abcd"
-
-# 最终 Curvine 路径
-实际路径: "/k8s-volumes/pvc-1234-5678-abcd"
-```
-
-### 3.4 创建 StorageClass
-
-创建 `storageclass.yaml` 文件：
+### 1. StorageClass
 
 ```yaml
 apiVersion: storage.k8s.io/v1
@@ -339,496 +64,181 @@ reclaimPolicy: Delete
 volumeBindingMode: Immediate
 allowVolumeExpansion: true
 parameters:
-  master-addrs: "m0:8995,m1:8995,m2:8995"
+  master-addrs: "curvine-master-0.curvine-master.curvine.svc.cluster.local:8995"
   fs-path: "/k8s-volumes"
   path-type: "DirectoryOrCreate"
 ```
 
-应用配置：
-
 ```bash
-# 创建 StorageClass
 kubectl apply -f storageclass.yaml
-
-# 查看 StorageClass
-kubectl get storageclass curvine-sc
-
-# 设为默认 StorageClass（可选）
-kubectl patch storageclass curvine-sc \
-  -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
 ```
 
-:::tip
-请将示例中的 `master-addrs` 替换为实际的 Master 地址。
-:::
-
-### 3.5 多 StorageClass 场景
-
-可为不同场景创建多个 StorageClass：
+### 2. PVC
 
 ```yaml
-# 生产环境 - 严格模式
----
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
+apiVersion: v1
+kind: PersistentVolumeClaim
 metadata:
-  name: curvine-prod
-provisioner: curvine
-reclaimPolicy: Retain
-volumeBindingMode: WaitForFirstConsumer
-parameters:
-  master-addrs: "prod-master1:8995,prod-master2:8995"
-  fs-path: "/production"
-  path-type: "Directory"
-
-# 开发环境 - 宽松模式
----
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  name: curvine-dev
-provisioner: curvine
-reclaimPolicy: Delete
-volumeBindingMode: Immediate
-parameters:
-  master-addrs: "dev-master:8995"
-  fs-path: "/development"
-  path-type: "DirectoryOrCreate"
+  name: app-data
+  namespace: curvine
+spec:
+  storageClassName: curvine-sc
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
 ```
 
----
-
-## 四、静态 PV 使用
-
-静态 PV 用于挂载 Curvine 中已存在的数据目录，适用于以下场景：
-- 多集群共享同一份数据
-- 需要精确控制数据路径
-
-### 4.1 工作原理
-
-```mermaid
-%%{init: {'theme': 'base', 'themeVariables': { 'background': '#ffffff', 'primaryColor': '#4a9eff', 'primaryTextColor': '#1a202c', 'primaryBorderColor': '#3182ce', 'lineColor': '#4a5568', 'secondaryColor': '#805ad5', 'tertiaryColor': '#38a169', 'mainBkg': '#ffffff', 'nodeBorder': '#4a5568', 'clusterBkg': '#f8f9fa', 'clusterBorder': '#dee2e6', 'titleColor': '#1a202c'}}}%%
-flowchart LR
-    Start[Curvine 集群中已有数据] --> CreatePV[管理员创建 PV<br/>指定 curvine-path]
-    CreatePV --> CreatePVC[用户创建 PVC<br/>绑定指定 PV]
-    CreatePVC --> MountPod[Pod 挂载 PVC]
-    
-    classDef storageStyle fill:#fc8181,stroke:#c53030,color:#1a202c,stroke-width:2px
-    classDef adminStyle fill:#4a9eff,stroke:#2b6cb0,color:#fff,stroke-width:2px
-    classDef userStyle fill:#805ad5,stroke:#553c9a,color:#fff,stroke-width:2px
-    classDef appStyle fill:#ed8936,stroke:#c05621,color:#fff,stroke-width:2px
-    
-    class Start storageStyle
-    class CreatePV adminStyle
-    class CreatePVC userStyle
-    class MountPod appStyle
+```bash
+kubectl apply -f pvc.yaml
+kubectl wait --for=condition=Bound pvc/app-data -n curvine --timeout=120s
 ```
 
-### 4.2 创建静态 PV
+### 3. Pod
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: app-pod
+  namespace: curvine
+spec:
+  containers:
+    - name: app
+      image: busybox:1.36
+      command: ["sh", "-c", "echo test > /data/test.txt && cat /data/test.txt && sleep 3600"]
+      volumeMounts:
+        - name: data
+          mountPath: /data
+  volumes:
+    - name: data
+      persistentVolumeClaim:
+        claimName: app-data
+```
+
+```bash
+kubectl apply -f pod.yaml
+kubectl logs app-pod -n curvine
+```
+
+## 示例二：静态 PV
+
+### 1. StorageClass
+
+同示例一。三副本时 `master-addrs` 同上。
+
+### 2. PV 与 PVC
 
 ```yaml
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: curvine-pv-existing-data
-  labels:
-    type: curvine-static
+  name: curvine-existing
 spec:
   storageClassName: curvine-sc
   capacity:
-    storage: 100Gi                    # 声明容量
+    storage: 10Gi
   accessModes:
-    - ReadWriteMany                   # 支持多 Pod 读写
-  persistentVolumeReclaimPolicy: Retain  # 保留数据
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
   csi:
     driver: curvine
-    volumeHandle: "existing-data-volume-001"  # 唯一标识
+    volumeHandle: "existing-data-001"
     volumeAttributes:
-      # 必填：Curvine Master 地址
-      master-addrs: "m0:8995,m1:8995,m2:8995"
-      
-      # 必填：Curvine 中的完整路径
-      curvine-path: "/production/user-data"
-      
-      # 推荐：使用 Directory 确保路径已存在
+      master-addrs: "curvine-master-0.curvine-master.curvine.svc.cluster.local:8995"
+      curvine-path: "/existing-data"
       path-type: "Directory"
-      
-      # 可选：FUSE 参数
-      io-threads: "4"
-      worker-threads: "8"
-```
-
-**参数说明：**
-- `volumeHandle`：任意唯一字符串，用于标识 PV
-- `curvine-path`：Curvine 文件系统中的完整路径，必须已存在
-- `path-type: Directory`：要求路径已存在（推荐）
-
-### 4.3 创建静态 PVC
-
-```yaml
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: curvine-pvc-existing-data
-  namespace: default
+  name: app-data
+  namespace: curvine
 spec:
   storageClassName: curvine-sc
   accessModes:
     - ReadWriteMany
   resources:
     requests:
-      storage: 100Gi
-  # 关键：指定要绑定的 PV 名称
-  volumeName: curvine-pv-existing-data
+      storage: 10Gi
+  volumeName: curvine-existing
 ```
-
-### 4.4 验证绑定
 
 ```bash
-# 检查 PV 状态
-kubectl get pv curvine-pv-existing-data
-# STATUS 应为 Bound
-
-# 检查 PVC 状态
-kubectl get pvc curvine-pvc-existing-data
-# STATUS 应为 Bound
-
-# 查看详细信息
-kubectl describe pvc curvine-pvc-existing-data
+kubectl apply -f pv-pvc.yaml
+kubectl wait --for=condition=Bound pvc/app-data -n curvine --timeout=120s
 ```
 
-### 4.5 在 Pod 中使用静态 PV
+### 3. Pod
 
 ```yaml
 apiVersion: v1
 kind: Pod
 metadata:
-  name: static-pv-test
+  name: app-pod
+  namespace: curvine
 spec:
   containers:
-  - name: app
-    image: nginx:alpine
-    volumeMounts:
-    - name: data
-      mountPath: /data
+    - name: app
+      image: busybox:1.36
+      command: ["sh", "-c", "echo test > /data/test.txt && cat /data/test.txt && sleep 3600"]
+      volumeMounts:
+        - name: data
+          mountPath: /data
   volumes:
-  - name: data
-    persistentVolumeClaim:
-      claimName: curvine-pvc-existing-data
-```
-
-## 五、动态 PV 使用
-
-动态 PV 是最常用的方式，由 CSI Controller 自动创建和管理。
-
-### 5.1 工作原理
-
-```mermaid
-%%{init: {'theme': 'base', 'themeVariables': { 'background': '#ffffff', 'primaryColor': '#4a9eff', 'primaryTextColor': '#1a202c', 'primaryBorderColor': '#3182ce', 'lineColor': '#4a5568', 'secondaryColor': '#805ad5', 'tertiaryColor': '#38a169', 'mainBkg': '#ffffff', 'nodeBorder': '#4a5568', 'clusterBkg': '#f8f9fa', 'clusterBorder': '#dee2e6', 'titleColor': '#1a202c'}}}%%
-flowchart LR
-    CreatePVC[用户创建 PVC<br/>指定 StorageClass] --> AutoCreatePV[CSI Provisioner<br/>自动创建 PV]
-    AutoCreatePV --> GenPath[自动生成 Curvine 路径<br/>fs-path + pv-name]
-    GenPath --> AutoBind[PVC 自动绑定 PV]
-    AutoBind --> MountPod[Pod 挂载 PVC 使用]
-    
-    classDef userStyle fill:#805ad5,stroke:#553c9a,color:#fff,stroke-width:2px
-    classDef csiStyle fill:#4a9eff,stroke:#2b6cb0,color:#fff,stroke-width:2px
-    classDef pathStyle fill:#48bb78,stroke:#276749,color:#fff,stroke-width:2px
-    classDef bindStyle fill:#ecc94b,stroke:#b7791f,color:#1a202c,stroke-width:2px
-    classDef appStyle fill:#ed8936,stroke:#c05621,color:#fff,stroke-width:2px
-    
-    class CreatePVC userStyle
-    class AutoCreatePV csiStyle
-    class GenPath pathStyle
-    class AutoBind bindStyle
-    class MountPod appStyle
-```
-
-### 5.2 创建动态 PVC
-
-动态 PVC 需要指定 StorageClass，不需要指定 `volumeName`：
-
-```yaml
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: my-dynamic-pvc
-  namespace: default
-spec:
-  storageClassName: curvine-sc    # 指定 StorageClass
-  accessModes:
-    - ReadWriteOnce               # 或 ReadWriteMany
-  resources:
-    requests:
-      storage: 10Gi               # 申请容量
-```
-
-### 5.3 自动路径生成示例
-
-```yaml
-# StorageClass 配置
-fs-path: "/k8s-volumes"
-
-# PVC 名称
-name: my-dynamic-pvc
-
-# 自动生成的 PV
-# volumeHandle: pvc-1a2b3c4d-5e6f-7g8h-9i0j-k1l2m3n4o5p6
-
-# 实际 Curvine 路径
-# /k8s-volumes/pvc-1a2b3c4d-5e6f-7g8h-9i0j-k1l2m3n4o5p6
-
-# 可使用 Curvine 的 cv 命令检查卷是否在集群中正确创建
-./bin/cv fs ls /
-```
-
-### 5.4 动态 PV 完整示例
-
-创建 `dynamic-pvc.yaml` 文件：
-
-```yaml
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: app-data-pvc
-  namespace: default
-spec:
-  storageClassName: curvine-sc
-  accessModes:
-    - ReadWriteMany
-  resources:
-    requests:
-      storage: 20Gi
-```
-
-创建 `dynamic-pv-pod.yaml` 文件：
-
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: dynamic-pv-test
-spec:
-  containers:
-  - name: app
-    image: nginx:alpine
-    volumeMounts:
     - name: data
-      mountPath: /usr/share/nginx/html
-  volumes:
-  - name: data
-    persistentVolumeClaim:
-      claimName: app-data-pvc
+      persistentVolumeClaim:
+        claimName: app-data
 ```
-
-应用配置：
 
 ```bash
-# 1. 创建动态 PVC
-kubectl apply -f dynamic-pvc.yaml
-
-# 2. 检查 PVC 状态（应自动变为 Bound）
-kubectl get pvc app-data-pvc
-kubectl describe pvc app-data-pvc
-
-# 3. 查看自动创建的 PV
-kubectl get pv
-
-# 4. 创建使用 PVC 的 Pod
-kubectl apply -f dynamic-pv-pod.yaml
-
-# 5. 测试读写
-kubectl exec dynamic-pv-test -- sh -c 'echo "Hello Curvine" > /usr/share/nginx/html/index.html'
-kubectl exec dynamic-pv-test -- cat /usr/share/nginx/html/index.html
+kubectl apply -f pod.yaml
+kubectl logs app-pod -n curvine
 ```
 
-## 下一步
+## 挂载模式
 
-- 在 `Deployment` 中共享 PVC，参考 [Deployment](02-Deployment.md)
-- 在 `StatefulSet` 中为每个副本分配独立 PVC，参考 [StatefulSet](03-StatefulSet.md)
-- 理解 `volumeHandle`、FUSE 复用和挂载路径生成规则，参考 [Framework](04-Framework.md)
+默认 `node.mountMode=embedded`，安装命令见「部署」。
 
-## 附录
+`standalone` 模式安装参数：
 
-### Helm 自定义参数
+| 参数 | 说明 |
+|------|------|
+| `node.mountMode=standalone` | 启用 standalone |
+| `node.standalone.resources.requests.cpu` | Standalone Pod CPU request |
+| `node.standalone.resources.requests.memory` | Standalone Pod 内存 request |
+| `node.standalone.resources.limits.cpu` | Standalone Pod CPU limit |
+| `node.standalone.resources.limits.memory` | Standalone Pod 内存 limit |
+| `node.standalone.image` | Standalone Pod 镜像，空值使用 CSI 镜像 |
 
-#### 全局配置
+## 配置参考
 
-| 参数路径 | 类型 | 默认值 | 说明 |
-|---------|------|--------|------|
-| `global.namespace` | string | `curvine` | CSI 驱动部署的命名空间 |
+### Helm 参数
 
-#### 镜像配置
+| 参数 | 默认值 |
+|------|--------|
+| `node.mountMode` | `embedded` |
+| `csiDriver.name` | `curvine` |
+| `image.repository` | `ghcr.io/curvineio/curvine-csi` |
 
-| 参数路径 | 类型 | 默认值 | 说明 |
-|---------|------|--------|------|
-| `image.repository` | string | `ghcr.io/curvineio/curvine-csi` | CSI 驱动镜像仓库地址 |
-| `image.tag` | string | `latest` | CSI 驱动镜像标签 |
-| `image.pullPolicy` | string | `Always` | 镜像拉取策略（Always/IfNotPresent/Never） |
-
-#### CSI 驱动配置
-
-| 参数路径 | 类型 | 默认值 | 说明 |
-|---------|------|--------|------|
-| `csiDriver.name` | string | `curvine` | CSI 驱动名称 |
-| `csiDriver.attachRequired` | boolean | `false` | 是否需要 Attach 操作 |
-| `csiDriver.podInfoOnMount` | boolean | `false` | 挂载时是否需要 Pod 信息 |
-
-#### Controller 配置
-
-| 参数路径 | 类型 | 默认值 | 说明 |
-|---------|------|--------|------|
-| `controller.name` | string | `curvine-csi-controller` | Controller Deployment 名称 |
-| `controller.replicas` | int | `1` | Controller 副本数 |
-| `controller.priorityClassName` | string | `system-cluster-critical` | Controller 优先级类 |
-| `controller.container.name` | string | `csi-plugin` | 主容器名称 |
-| `controller.container.command` | array | `["/opt/curvine/csi"]` | 容器启动命令 |
-| `controller.container.args` | array | 见 values.yaml | 容器启动参数 |
-| `controller.container.env.CSI_ENDPOINT` | string | `unix:///csi/csi.sock` | CSI 套接字端点 |
-| `controller.container.livenessProbe.failureThreshold` | int | `5` | 存活探针失败阈值 |
-| `controller.container.livenessProbe.httpGet.path` | string | `"/healthz"` | 存活探针 HTTP 路径 |
-| `controller.container.livenessProbe.httpGet.port` | string | `healthz` | 存活探针 HTTP 端口名 |
-| `controller.container.livenessProbe.initialDelaySeconds` | int | `10` | 存活探针初始延迟（秒） |
-| `controller.container.livenessProbe.periodSeconds` | int | `10` | 存活探针检查周期（秒） |
-| `controller.container.livenessProbe.timeoutSeconds` | int | `3` | 存活探针超时（秒） |
-| `controller.container.ports.healthz` | int | `9909` | 健康检查端口 |
-| `controller.container.securityContext.privileged` | boolean | `true` | 是否以特权模式运行 |
-| `controller.container.securityContext.capabilities.add` | array | `[SYS_ADMIN]` | 添加的 Linux Capabilities |
-| `controller.tolerations` | array | 见 values.yaml | Pod 容忍度配置 |
-
-#### Controller Sidecar 配置
-
-| 参数路径 | 类型 | 默认值 | 说明 |
-|---------|------|--------|------|
-| `controller.sidecars.provisioner.image` | string | `quay.io/k8scsi/csi-provisioner:v1.6.0` | Provisioner sidecar 镜像 |
-| `controller.sidecars.provisioner.args` | array | 见 values.yaml | Provisioner 参数 |
-| `controller.sidecars.attacher.image` | string | `registry.k8s.io/sig-storage/csi-attacher:v4.5.0` | Attacher sidecar 镜像 |
-| `controller.sidecars.attacher.args` | array | 见 values.yaml | Attacher 参数 |
-| `controller.sidecars.livenessProbe.image` | string | `registry.k8s.io/sig-storage/livenessprobe:v2.11.0` | LivenessProbe sidecar 镜像 |
-| `controller.sidecars.livenessProbe.args` | array | 见 values.yaml | LivenessProbe 参数 |
-| `controller.sidecars.livenessProbe.env.HEALTH_PORT` | string | `"9909"` | 健康检查端口 |
-
-#### Node 配置
-
-| 参数路径 | 类型 | 默认值 | 说明 |
-|---------|------|--------|------|
-| `node.name` | string | `curvine-csi-node` | Node DaemonSet 名称 |
-| `node.priorityClassName` | string | `system-node-critical` | Node 优先级类 |
-| `node.dnsPolicy` | string | `ClusterFirstWithHostNet` | DNS 策略 |
-| `node.fuseDebugEnabled` | boolean | `false` | 是否启用 FUSE 调试模式 |
-| `node.mountMode` | string | `embedded` | 挂载模式：`embedded`（FUSE 在 CSI 容器内，默认）或 `standalone`（独立 FUSE Pod） |
-| `node.container.name` | string | `csi-plugin` | 主容器名称 |
-| `node.container.command` | array | `["/opt/curvine/csi"]` | 容器启动命令 |
-| `node.container.args` | array | 见 values.yaml | 容器启动参数 |
-| `node.container.env.CSI_ENDPOINT` | string | `unix:///csi/csi.sock` | CSI 套接字端点 |
-| `node.container.livenessProbe.failureThreshold` | int | `5` | 存活探针失败阈值 |
-| `node.container.livenessProbe.httpGet.path` | string | `"/healthz"` | 存活探针 HTTP 路径 |
-| `node.container.livenessProbe.httpGet.port` | string | `healthz` | 存活探针 HTTP 端口名 |
-| `node.container.livenessProbe.initialDelaySeconds` | int | `10` | 存活探针初始延迟（秒） |
-| `node.container.livenessProbe.periodSeconds` | int | `10` | 存活探针检查周期（秒） |
-| `node.container.livenessProbe.timeoutSeconds` | int | `3` | 存活探针超时（秒） |
-| `node.container.ports.healthz` | int | `9909` | 健康检查端口 |
-| `node.container.securityContext.privileged` | boolean | `true` | 是否以特权模式运行 |
-| `node.container.lifecycle.preStop` | object | 见 values.yaml | 容器停止前钩子 |
-| `node.tolerations` | array | `[{operator: Exists}]` | Pod 容忍度配置 |
-
-#### Embedded 模式配置
-
-当 `node.mountMode` 为 `embedded`（默认）时，资源限制作用于 CSI node 容器：
-
-| 参数路径 | 类型 | 默认值 | 说明 |
-|---------|------|--------|------|
-| `node.container.resources.requests.cpu` | string | `"500m"` | CPU 请求 |
-| `node.container.resources.requests.memory` | string | `"512Mi"` | 内存请求 |
-| `node.container.resources.limits.cpu` | string | `"2"` | CPU 限制 |
-| `node.container.resources.limits.memory` | string | `"2Gi"` | 内存限制 |
-
-示例配置：
-
-```yaml
-node:
-  mountMode: embedded
-  container:
-    resources:
-      requests:
-        cpu: "500m"
-        memory: "512Mi"
-      limits:
-        cpu: "2"
-        memory: "2Gi"
+```bash
+helm show values curvine/curvine-csi --version 0.3.2-alpha
 ```
 
-#### Standalone Pod 配置
+### Curvine 卷参数
 
-当 `node.mountMode` 设为 `standalone` 时，适用以下配置：
+| 参数 | 必填 | 说明 |
+|------|------|------|
+| `master-addrs` | 是 | `host:port`，逗号分隔 |
+| `fs-path` | 动态供给 | 路径前缀 |
+| `curvine-path` | 静态卷 | 完整路径 |
+| `path-type` | 否 | `DirectoryOrCreate` 或 `Directory` |
 
-| 参数路径 | 类型 | 默认值 | 说明 |
-|---------|------|--------|------|
-| `node.standalone.image` | string | `""` | Standalone Pod 镜像，为空则使用 CSI 镜像 |
-| `node.standalone.resources.requests.cpu` | string | `"500m"` | CPU 请求 |
-| `node.standalone.resources.requests.memory` | string | `"512Mi"` | 内存请求 |
-| `node.standalone.resources.limits.cpu` | string | `"2"` | CPU 限制 |
-| `node.standalone.resources.limits.memory` | string | `"2Gi"` | 内存限制 |
+## 故障排查
 
-示例配置：
-
-```yaml
-node:
-  mountMode: standalone
-  standalone:
-    image: ""
-    resources:
-      requests:
-        cpu: "500m"
-        memory: "512Mi"
-      limits:
-        cpu: "2"
-        memory: "2Gi"
-```
-
-#### Node Sidecar 配置
-
-| 参数路径 | 类型 | 默认值 | 说明 |
-|---------|------|--------|------|
-| `node.sidecars.nodeDriverRegistrar.image` | string | `quay.io/k8scsi/csi-node-driver-registrar:v2.1.0` | Node 驱动注册器镜像 |
-| `node.sidecars.nodeDriverRegistrar.args` | array | 见 values.yaml | 注册器参数 |
-| `node.sidecars.nodeDriverRegistrar.env.ADDRESS` | string | `/csi/csi.sock` | CSI 套接字地址 |
-| `node.sidecars.nodeDriverRegistrar.env.DRIVER_REG_SOCK_PATH` | string | `/var/lib/kubelet/csi-plugins/csi.curvine.io/csi.sock` | Kubelet 中驱动注册路径 |
-| `node.sidecars.livenessProbe.image` | string | `registry.k8s.io/sig-storage/livenessprobe:v2.11.0` | LivenessProbe sidecar 镜像 |
-| `node.sidecars.livenessProbe.args` | array | 见 values.yaml | LivenessProbe 参数 |
-| `node.sidecars.livenessProbe.env.ADDRESS` | string | `/csi/csi.sock` | CSI 套接字地址 |
-| `node.sidecars.livenessProbe.env.HEALTH_PORT` | string | `"9909"` | 健康检查端口 |
-
-#### Node 主机路径配置
-
-| 参数路径 | 类型 | 默认值 | 说明 |
-|---------|------|--------|------|
-| `node.hostPaths.pluginDir.path` | string | `/var/lib/kubelet/csi-plugins/csi.curvine.io/` | CSI 插件目录路径 |
-| `node.hostPaths.pluginDir.type` | string | `DirectoryOrCreate` | 路径类型 |
-| `node.hostPaths.kubeletDir.path` | string | `/var/lib/kubelet` | Kubelet 工作目录 |
-| `node.hostPaths.kubeletDir.type` | string | `DirectoryOrCreate` | 路径类型 |
-| `node.hostPaths.registrationDir.path` | string | `/var/lib/kubelet/plugins_registry/` | 插件注册目录 |
-| `node.hostPaths.registrationDir.type` | string | `Directory` | 路径类型 |
-
-#### 服务账号配置
-
-| 参数路径 | 类型 | 默认值 | 说明 |
-|---------|------|--------|------|
-| `serviceAccount.controller.name` | string | `curvine-csi-controller-sa` | Controller 服务账号名称 |
-| `serviceAccount.node.name` | string | `curvine-csi-node-sa` | Node 服务账号名称 |
-
-#### RBAC 配置
-
-| 参数路径 | 类型 | 默认值 | 说明 |
-|---------|------|--------|------|
-| `rbac.create` | boolean | `true` | 是否创建 RBAC 资源 |
-
-#### StorageClass 参数（使用时配置）
-
-| 参数名 | 必填 | 类型 | 默认值 | 说明 |
-|--------|---------|------|--------|------|
-| `master-addrs` | **必填** | string | 无 | Curvine Master 节点地址，格式：`host:port,host:port` |
-| `fs-path` | **必填** | string | 无 | 文件系统路径前缀，每个 PV 创建：`fs-path + pv-name` |
-| `path-type` | 可选 | string | `Directory` | 路径创建策略：`DirectoryOrCreate` 或 `Directory` |
-| `io-threads` | 可选 | string | 无 | FUSE IO 线程数 |
-| `worker-threads` | 可选 | string | 无 | FUSE 工作线程数 |
+| 现象 | 处理 |
+|------|------|
+| CSI Pod 异常 | `kubectl logs -n curvine-system -l app=curvine-csi-node -c csi-plugin` |
+| `master-addrs` 不可达 | `kubectl get pods -n curvine` |
+| 挂载断开 | 重启应用 Pod |


### PR DESCRIPTION
## Problem
The CSI setup page mixed Kubernetes storage concepts, outdated image repos, and fragmented examples, making end-to-end testing difficult.

## Design
Focus on Curvine CSI install and two step-by-step examples (dynamic PV, static PV). Use Helm --set for standalone mode. Default master-addrs to single-replica pod DNS with a three-replica note.

## Key Changes
- Rewrite `01-Setup.md` (en + zh-cn)
- Align with curvine cluster Helm install and `curvine-system` namespace
- Remove sidecar image workaround (fixed in curvine-helm)