### PR TITLE
docs(i18n): align zh-cn Helm and CSI deployment docs with English

### DIFF
--- a/docs/3-User-Manuals/5-K8S-CSI-Driver/01-Setup.md
+++ b/docs/3-User-Manuals/5-K8S-CSI-Driver/01-Setup.md
@@ -64,7 +64,7 @@ reclaimPolicy: Delete
 volumeBindingMode: Immediate
 allowVolumeExpansion: true
 parameters:
-  master-addrs: "curvine-master-0.curvine-master.curvine.svc.cluster.local:8995"
+  master-addrs: "curvine-master.curvine.svc.cluster.local:8995"
   fs-path: "/k8s-volumes"
   path-type: "DirectoryOrCreate"
 ```
@@ -146,7 +146,7 @@ spec:
     driver: curvine
     volumeHandle: "existing-data-001"
     volumeAttributes:
-      master-addrs: "curvine-master-0.curvine-master.curvine.svc.cluster.local:8995"
+      master-addrs: "curvine-master.curvine.svc.cluster.local:8995"
       curvine-path: "/existing-data"
       path-type: "Directory"
 ---

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/01-k8s-Deployment.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/01-k8s-Deployment.md
@@ -17,7 +17,7 @@ Chart：`curvine/curvine`，版本 `0.3.2-alpha`。
 Helm release `curvine` 部署于 namespace `curvine`：
 
 | 资源 | 说明 |
-|------|------|
+|----------|-------------|
 | StatefulSet `curvine-master` | 元数据、Raft journal |
 | StatefulSet `curvine-worker` | 数据节点 |
 | Service `curvine-master` | Headless，RPC 8995 |
@@ -93,7 +93,7 @@ kubectl delete namespace curvine
 ## 故障排查
 
 | 现象 | 命令 | 原因 |
-|------|------|------|
+|---------|---------|-------|
 | Pod Pending | `kubectl describe pod -n curvine <name>` | 资源不足；无 StorageClass |
 | master 启动慢 | `kubectl logs curvine-master-0 -n curvine` | Raft 回放中 |
 | PVC Pending | `kubectl get sc` | 无可用 StorageClass |
@@ -105,13 +105,13 @@ Chart 版本 `0.3.2-alpha`。下表默认值与 `helm show values curvine/curvin
 ### 全局
 
 | 参数 | 默认值 | 说明 |
-|------|--------|------|
+|-----------|---------|-------------|
 | `global.clusterDomain` | `cluster.local` | Kubernetes 集群域名 |
 
 ### 集群
 
 | 参数 | 默认值 | 说明 |
-|------|--------|------|
+|-----------|---------|-------------|
 | `cluster.id` | `curvine` | 集群 ID |
 | `cluster.formatMaster` | `false` | 启动时格式化 master 数据 |
 | `cluster.formatWorker` | `false` | 启动时格式化 worker 数据 |
@@ -120,7 +120,7 @@ Chart 版本 `0.3.2-alpha`。下表默认值与 `helm show values curvine/curvin
 ### 镜像
 
 | 参数 | 默认值 | 说明 |
-|------|--------|------|
+|-----------|---------|-------------|
 | `image.repository` | `ghcr.io/curvineio/curvine` | 镜像仓库 |
 | `image.tag` | `""` | 空值使用 `v{Chart.AppVersion}` |
 | `image.pullPolicy` | `IfNotPresent` | 镜像拉取策略 |
@@ -133,7 +133,7 @@ Chart 版本 `0.3.2-alpha`。下表默认值与 `helm show values curvine/curvin
 设 `openKruise.enabled=true` 时安装 kruise 子 chart，并将 master/worker 切换为 Advanced StatefulSet（`apps.kruise.io/v1beta1`）。
 
 | 参数 | 默认值 | 说明 |
-|------|--------|------|
+|-----------|---------|-------------|
 | `openKruise.enabled` | `false` | 启用 Advanced StatefulSet |
 | `openKruise.podUpdatePolicy` | `InPlaceOnly` | `InPlaceOnly` \| `InPlaceIfPossible` \| `ReCreate` |
 | `openKruise.persistentPodState.autoGenerate` | `true` | 自动生成 PersistentPodState |
@@ -145,7 +145,7 @@ Chart 版本 `0.3.2-alpha`。下表默认值与 `helm show values curvine/curvin
 ### Master
 
 | 参数 | 默认值 | 说明 |
-|------|--------|------|
+|-----------|---------|-------------|
 | `master.replicas` | `1` | 须为奇数（1、3、5…） |
 | `master.rpcPort` | `8995` | RPC 端口 |
 | `master.journalPort` | `8996` | Journal/Raft 端口 |
@@ -178,7 +178,7 @@ Chart 版本 `0.3.2-alpha`。下表默认值与 `helm show values curvine/curvin
 ### Worker
 
 | 参数 | 默认值 | 说明 |
-|------|--------|------|
+|-----------|---------|-------------|
 | `worker.replicas` | `1` | Worker 副本数 |
 | `worker.rpcPort` | `8997` | RPC 端口 |
 | `worker.webPort` | `9001` | Web UI 端口 |
@@ -210,7 +210,7 @@ Chart 版本 `0.3.2-alpha`。下表默认值与 `helm show values curvine/curvin
 ### Service
 
 | 参数 | 默认值 | 说明 |
-|------|--------|------|
+|-----------|---------|-------------|
 | `service.master.type` | `ClusterIP` | Headless（`ClusterIP: None`） |
 | `service.worker.type` | `ClusterIP` | Headless（`ClusterIP: None`） |
 | `service.masterExternal.enabled` | `false` | 外部访问 master |
@@ -220,7 +220,7 @@ Chart 版本 `0.3.2-alpha`。下表默认值与 `helm show values curvine/curvin
 ### ServiceAccount 与 RBAC
 
 | 参数 | 默认值 | 说明 |
-|------|--------|------|
+|-----------|---------|-------------|
 | `serviceAccount.create` | `true` | 创建 ServiceAccount |
 | `serviceAccount.name` | `""` | 空值自动生成 |
 | `rbac.create` | `true` | 创建 RBAC 资源 |
@@ -228,7 +228,7 @@ Chart 版本 `0.3.2-alpha`。下表默认值与 `helm show values curvine/curvin
 ### Curvine 配置（`config.*`）
 
 | 参数 | 默认值 | 说明 |
-|------|--------|------|
+|-----------|---------|-------------|
 | `config.master.metaDir` | `/opt/curvine/data/meta` | Master 元数据目录 |
 | `config.journal.enable` | `true` | 启用 journal |
 | `config.journal.journalDir` | `/opt/curvine/data/journal` | Journal 目录 |
@@ -244,7 +244,7 @@ Chart 版本 `0.3.2-alpha`。下表默认值与 `helm show values curvine/curvin
 按 TOML 分段覆盖，无需替换完整配置：
 
 | 参数 | 默认值 | 说明 |
-|------|--------|------|
+|-----------|---------|-------------|
 | `configOverrides.master` | `{}` | Master 段覆盖 |
 | `configOverrides.journal` | `{}` | Journal 段覆盖 |
 | `configOverrides.worker` | `{}` | Worker 段覆盖 |
@@ -254,7 +254,7 @@ Chart 版本 `0.3.2-alpha`。下表默认值与 `helm show values curvine/curvin
 ### 存储方式
 
 | 方式 | 配置 |
-|------|------|
+|------|---------------|
 | PVC（默认） | `storageClass: ""` 使用集群 default StorageClass |
 | 指定 StorageClass | `master.storage.*.storageClass`、`worker.storage.dataDirs[].storageClass` |
 | hostPath | `storageClass: ""` 并设置 `hostPath` |

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/3-User-Manuals/5-K8S-CSI-Driver/01-Setup.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/3-User-Manuals/5-K8S-CSI-Driver/01-Setup.md
@@ -1,4 +1,4 @@
-# K8S CSI Driver
+# K8S CSI 驱动
 
 前提：已通过 Helm 部署 curvine cluster（namespace `curvine`）。
 
@@ -7,7 +7,7 @@ Chart：`curvine/curvine-csi`，版本 `0.3.2-alpha`。Release namespace：`curv
 ## 架构说明
 
 | 组件 | 类型 | 说明 |
-|------|------|------|
+|-----------|------|-------------|
 | CSI Controller | Deployment | 卷创建、删除 |
 | CSI Node | DaemonSet | 节点挂载 |
 
@@ -64,7 +64,7 @@ reclaimPolicy: Delete
 volumeBindingMode: Immediate
 allowVolumeExpansion: true
 parameters:
-  master-addrs: "curvine-master-0.curvine-master.curvine.svc.cluster.local:8995"
+  master-addrs: "curvine-master.curvine.svc.cluster.local:8995"
   fs-path: "/k8s-volumes"
   path-type: "DirectoryOrCreate"
 ```
@@ -146,7 +146,7 @@ spec:
     driver: curvine
     volumeHandle: "existing-data-001"
     volumeAttributes:
-      master-addrs: "curvine-master-0.curvine-master.curvine.svc.cluster.local:8995"
+      master-addrs: "curvine-master.curvine.svc.cluster.local:8995"
       curvine-path: "/existing-data"
       path-type: "Directory"
 ---
@@ -204,7 +204,7 @@ Chart 版本 `0.3.2-alpha`。下表默认值与 `helm show values curvine/curvin
 ### 镜像
 
 | 参数 | 默认值 | 说明 |
-|------|--------|------|
+|-----------|---------|-------------|
 | `image.repository` | `ghcr.io/curvineio/curvine-csi` | CSI 镜像仓库 |
 | `image.tag` | `""` | 空值使用 `v{Chart.AppVersion}` |
 | `image.pullPolicy` | `Always` | 镜像拉取策略 |
@@ -212,7 +212,7 @@ Chart 版本 `0.3.2-alpha`。下表默认值与 `helm show values curvine/curvin
 ### CSI 驱动
 
 | 参数 | 默认值 | 说明 |
-|------|--------|------|
+|-----------|---------|-------------|
 | `csiDriver.name` | `curvine` | CSI 驱动名称 |
 | `csiDriver.attachRequired` | `false` | 不需要 attach 操作 |
 | `csiDriver.podInfoOnMount` | `false` | 挂载时不需要 Pod 信息 |
@@ -220,7 +220,7 @@ Chart 版本 `0.3.2-alpha`。下表默认值与 `helm show values curvine/curvin
 ### Controller
 
 | 参数 | 默认值 | 说明 |
-|------|--------|------|
+|-----------|---------|-------------|
 | `controller.name` | `curvine-csi-controller` | Deployment 名称 |
 | `controller.replicas` | `1` | Controller 副本数 |
 | `controller.priorityClassName` | `system-cluster-critical` | 优先级类 |
@@ -242,14 +242,14 @@ Chart 版本 `0.3.2-alpha`。下表默认值与 `helm show values curvine/curvin
 ### Node
 
 | 参数 | 默认值 | 说明 |
-|------|--------|------|
+|-----------|---------|-------------|
 | `node.name` | `curvine-csi-node` | DaemonSet 名称 |
 | `node.priorityClassName` | `system-node-critical` | 优先级类 |
 | `node.dnsPolicy` | `ClusterFirstWithHostNet` | DNS 策略 |
 | `node.fuseDebugEnabled` | `false` | FUSE 调试日志 |
 | `node.mountMode` | `embedded` | `embedded` 或 `standalone` |
-| `node.container.name` | `csi-plugin` | 主容器名称 |
-| `node.container.env.CSI_ENDPOINT` | `unix:///csi/csi.sock` | CSI 套接字 |
+| `node.container.name` | `csi-plugin` | Main container name |
+| `node.container.env.CSI_ENDPOINT` | `unix:///csi/csi.sock` | CSI socket |
 | `node.container.ports.healthz` | `9909` | 健康检查端口 |
 | `node.container.ports.metrics` | `9002` | 指标端口 |
 | `node.container.securityContext.privileged` | `true` | 特权模式 |
@@ -268,7 +268,7 @@ Chart 版本 `0.3.2-alpha`。下表默认值与 `helm show values curvine/curvin
 FUSE 运行在独立 Pod 中。适用于 CSI node Pod 重启后仍需保持 FUSE 挂载的场景。
 
 | 参数 | 默认值 | 说明 |
-|------|--------|------|
+|-----------|---------|-------------|
 | `node.standalone.image` | `""` | Standalone Pod 镜像，空值使用 CSI 镜像 |
 | `node.standalone.resources.requests.cpu` | `500m` | CPU request |
 | `node.standalone.resources.requests.memory` | `512Mi` | 内存 request |
@@ -278,7 +278,7 @@ FUSE 运行在独立 Pod 中。适用于 CSI node Pod 重启后仍需保持 FUSE
 ### ServiceAccount 与 RBAC
 
 | 参数 | 默认值 | 说明 |
-|------|--------|------|
+|-----------|---------|-------------|
 | `serviceAccount.controller.name` | `""` | 空值由 release 名称派生 |
 | `serviceAccount.node.name` | `""` | 空值由 release 名称派生 |
 | `rbac.create` | `true` | 创建 RBAC 资源 |
@@ -288,7 +288,7 @@ FUSE 运行在独立 Pod 中。适用于 CSI node Pod 重启后仍需保持 FUSE
 用于 StorageClass `parameters`（动态 PV）或 PV `csi.volumeAttributes`（静态 PV）。
 
 | 参数 | 必填 | 默认值 | 说明 |
-|------|------|--------|------|
+|-----------|----------|---------|-------------|
 | `master-addrs` | 是 | — | Curvine master 地址，`host:port` 逗号分隔 |
 | `fs-path` | 动态 PV | `/` | 路径前缀；实际路径为 `fs-path` + `/` + pv-name |
 | `curvine-path` | 静态 PV | — | Curvine 文件系统中的完整路径 |
@@ -315,7 +315,7 @@ helm show values curvine/curvine-csi --version 0.3.2-alpha
 ## 故障排查
 
 | 现象 | 处理 |
-|------|------|
+|---------|--------|
 | CSI Pod 异常 | `kubectl logs -n curvine-system -l app=curvine-csi-node -c csi-plugin` |
 | Sidecar ImagePullBackOff | 覆盖 sidecar 镜像，见「配置参考」 |
 | `master-addrs` 不可达 | `kubectl get pods -n curvine` |


### PR DESCRIPTION
## Summary

- Regenerate `zh-cn` pages for `curvine/curvine` Kubernetes deployment and `curvine/curvine-csi` install guide from the English sources, keeping identical structure, code blocks, and configuration tables.
- Translate CSI page title to `K8S CSI 驱动` for the Chinese site sidebar.
- Fix CSI examples to use `curvine-master.curvine.svc.cluster.local:8995` for single-replica clusters, consistent with the runtime deployment guide.

## Test plan

- [ ] Open `/zh-cn/docs/.../01-k8s-Deployment` and verify sections match the English page
- [ ] Open `/zh-cn/docs/.../5-K8S-CSI-Driver/01-Setup` and verify install examples and configuration reference
- [ ] Confirm code blocks are identical between `en` and `zh-cn` for both pages