### PR TITLE
docs(blog): add AI Agent EKS storage article

### DIFF
--- a/blog/2026-04-06-curvine-metadata-benchmark/index.md
+++ b/blog/2026-04-06-curvine-metadata-benchmark/index.md
@@ -1,6 +1,5 @@
 # Curvine Benchmark: 300 Million Files in Just 38 GB of Memory
 
-*Translated from the original Chinese article published on April 6, 2026.*
 
 In distributed file systems, metadata memory efficiency, concurrent request handling, and small-file throughput are core indicators of overall system capability. Curvine recently completed a high-intensity metadata benchmark, and the results were clear: Curvine reached a new high-water mark for open-source metadata efficiency while delivering core capabilities comparable to commercial distributed storage products.
 

--- a/blog/2026-06-12-curvine-spdk-nvme-performance/index.md
+++ b/blog/2026-06-12-curvine-spdk-nvme-performance/index.md
@@ -1,7 +1,5 @@
 # Performance Leap: How Curvine Uses SPDK to Unlock the Full Potential of NVMe Drives
 
-*Translated from the original Chinese article published on WeChat.*
-
 ## Introduction
 
 As data volumes continue to grow explosively, storage performance has become a key factor in application responsiveness and user experience. Traditional storage I/O paths are often constrained by operating-system kernel overhead, making it difficult to fully utilize modern high-speed storage devices such as NVMe SSDs. To break through this bottleneck, many high-performance storage systems have started to adopt kernel-bypass technologies. This article takes a closer look at how the Curvine storage platform integrates SPDK (Storage Performance Development Kit) to deliver extreme NVMe storage performance, bringing users lower latency and higher throughput.

--- a/blog/2026-07-07-ai-agent-storage-curvine-eks/index.md
+++ b/blog/2026-07-07-ai-agent-storage-curvine-eks/index.md
@@ -1,0 +1,191 @@
+# AI Agent Storage Selection: How Curvine Supports 10,000-Scale Agent Workloads on EKS
+
+## I. The Storage Challenge of Large-Scale AI Agent Deployment
+
+In 2026, AI infrastructure is undergoing a fundamental architectural shift: from a centralized model where one large model instance serves all requests, to a distributed model where thousands of Agent instances run independently.
+
+This is not a conceptual change. Take frontend development with Vite as an example: during debugging, an Agent needs to run build tools like Vite. The Vite dev server depends on high-speed random reads of `node_modules` and source directories for on-demand compilation and Hot Module Replacement (HMR). Developers expect to see page changes within milliseconds after saving a file. This places high demands on small-file random read performance and low-latency file system event notifications (`inotify`/`fswatch`). If the storage layer cannot keep up, the entire development experience becomes sluggish.
+
+Every Agent instance is not a stateless HTTP handler, but a stateful process with its own working directory and persistent storage needs. Platforms like OpenClaw build their entire memory and collaboration system on files: `SOUL.md` defines the agent's personality and behavioral boundaries, `AGENTS.md` describes behavior rules and session workflows, `MEMORY.md` stores long-term memory across sessions, plus `USER.md`, `TOOLS.md`, `HEARTBEAT.md`, and other Markdown files automatically loaded at startup — along with project source code, `node_modules`, and `.git` history. Each agent instance runs in an isolated sandbox where these files are constantly read, written, and updated. When a platform allocates dedicated agent instances to thousands of developers simultaneously, you get a classic "tens of thousands of independent file systems" requirement: each instance needs an isolated POSIX workspace with dense file counts and frequent I/O.
+
+From Kubernetes' perspective, this means your cluster must simultaneously support thousands or even tens of thousands of independent PersistentVolumeClaims. Each PVC must provision quickly — Agent elastic scaling cannot wait minutes for storage. You need low-latency file I/O, and data must remain accessible after a Pod is rescheduled to another node.
+
+This "massive small-scale stateful instances" workload pattern is fundamentally different from traditional stateful applications like databases and message queues, which typically use a few large PVCs. The former requires tens of thousands of small PVCs. Native AWS storage services each have different strengths and weaknesses when facing this new pattern.
+
+### 1.1 Amazon EBS: Strong Isolation, but Attachment Limits Are Hard Constraints
+
+EBS excels at isolation. One independent EBS volume per Agent means performance does not interfere across tenants, and failures do not spread. For scenarios requiring strict tenant isolation, this is the cleanest approach.
+
+The problem: the number of EBS volumes a single EC2 instance can attach has a hard upper limit. For most Nitro instances (including the r6g series used in this test), the maximum attachment count is 28, shared with network interfaces and NVMe instance store. After accounting for the primary network interface, the practical EBS volume limit is around 27. Some 7th-generation instance types (such as M7i and R7i) introduced independent EBS volume limits with higher quotas based on instance size, but for r6g instances still under shared limits, 28 is the ceiling. (Reference: [Amazon EBS volume limits for Amazon EC2 instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/volume_limits.html))
+
+What does this mean in practice? In our test scenario, each r6g.4xlarge node ran approximately 100 Agent Pods. If EBS allocated an independent volume to each Pod, a single node could mount at most 28 volumes — requiring nearly 4× the number of nodes to carry the same Pod density, dropping compute resource utilization from 88% to around 20%.
+
+Additionally, EBS volumes are bound to a single Availability Zone and cannot be used across AZs. Once a Pod is scheduled to a node in a different AZ, the original EBS volume becomes unreachable, forcing Pod scheduling constraints to specific AZs. For Agent platforms requiring cross-AZ high availability and rapid elastic scaling, this is an architectural hard constraint.
+
+### 1.2 Amazon EFS: Mature Isolation, but Mass Provisioning Is the Bottleneck
+
+As a managed NFS file system, EFS combined with Access Points can allocate an isolated directory view for each Agent. Each Access Point has independent POSIX permissions and a root directory, achieving file-system-level tenant isolation. EFS supports ReadWriteMany, so Pods can be rescheduled across nodes without detach/attach operations — ideal from a scheduling flexibility perspective. Since February 2025, a single EFS file system supports up to 10,000 Access Points, sufficient for tens-of-thousands Agent scenarios from a quota perspective.
+
+However, in actual large-scale deployments, the bottleneck appears in provisioning speed. When dynamically provisioning thousands of PVCs simultaneously through the EFS CSI Driver, each PVC corresponds to an Access Point creation. The EFS API has rate limits on Access Point creation, and the CSI controller must call the API serially or in small batches.
+
+### 1.3 Amazon S3: Unlimited Capacity, but Not a File System
+
+S3's scalability and cost efficiency are undeniable — it works well as the final archival layer for Agent data. But Agents at runtime need POSIX file semantics: `open`, `read`, `write`, `seek`, `rename`, and `list directory`. S3 is object storage — it does not support in-place modification, atomic rename, or consistent directory listing semantics.
+
+Mountpoint for Amazon S3 provides a FUSE mount solution, but it explicitly supports only sequential writes to new files and reads of existing files — not random writes or modifications to existing files. For Agent workflows that repeatedly modify context files, append logs, and update checkpoints, this is not a viable runtime storage solution.
+
+## II. Curvine: A Distributed Cache File System Designed for Agent Scale
+
+Curvine is a high-performance distributed cache file system written from scratch in Rust. The name comes from "Curvature Engine" — the faster-than-light propulsion device from Liu Cixin's *The Three-Body Problem* — symbolizing extreme acceleration of data access.
+
+Its core approach: build a distributed file system cache layer on top of cloud object storage (such as S3), providing complete POSIX semantics upward and using object storage as the persistence layer. For Kubernetes workloads, it integrates natively through a CSI driver, mounted directly as PVCs.
+
+### 2.1 Core Architecture
+
+Curvine uses a Master-Worker architecture:
+
+- **Master nodes**: Manage metadata, coordinate Workers, and handle load balancing. Raft consensus ensures metadata consistency and high availability.
+- **Worker nodes**: Handle actual data caching and serving. Support multi-tier caching across memory, SSD, and HDD, with hot data automatically promoted to faster tiers.
+- **Client access**: POSIX file system interface via FUSE mount; also compatible with S3 and HDFS protocols for integration with existing AI/big data ecosystems.
+
+In Kubernetes environments, Curvine integrates as a CSI driver: the CSI Controller handles dynamic PVC provisioning, and the CSI Node DaemonSet runs on each node to handle FUSE mounts. This means storage provisioning does not call external cloud APIs — it simply creates a directory on the distributed file system, completing in milliseconds.
+
+### 2.2 How Curvine Differs from JuiceFS
+
+JuiceFS is a pioneer in this space, implemented in Go with a similar "metadata engine + object storage" architecture. Key differences:
+
+- **Performance**: Curvine implements core read/write paths in Rust with zero-copy techniques, targeting 100μs-level latency and 100K+ stable QPS. Rust's async runtime (tokio) and GC-free memory model theoretically offer advantages over Go's runtime in high-concurrency small-file scenarios.
+- **Metadata capacity**: Curvine supports up to 5 billion small files per cluster — tens of thousands of Agents each producing small files creates significant metadata pressure.
+- **Metadata independence**: Curvine's file metadata paths correspond one-to-one with underlying S3 object paths. Even if Curvine services fail, files on S3 retain their original structure and remain independently accessible. JuiceFS splits files into blocks, making original files unrecognizable from S3 object names — metadata availability strongly depends on JuiceFS itself.
+- **Cache architecture**: Curvine natively supports automatic multi-tier grading from memory → SSD → HDD. JuiceFS also has local cache capabilities, but Curvine offers more fine-grained cache scheduling strategies.
+- **Positioning**: JuiceFS focuses more on general scenarios and deep cloud vendor integration. Curvine explicitly targets AI training acceleration and Agent cloud-native storage as primary use cases.
+
+Both are excellent open-source projects with active communities, each optimized for different design goals. Specific choices should be evaluated through actual testing based on workload characteristics, team technology stack, and operational preferences. This article does not constitute a recommendation.
+
+### 2.3 CSI Integration
+
+StorageClass configuration for Curvine on EKS:
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: curvine-sc
+provisioner: curvine
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+allowVolumeExpansion: true
+parameters:
+  master-addrs: "curvine-master-0.curvine-master.curvine.svc.cluster.local:8995"
+  fs-path: "/k8s-volumes"
+  path-type: "DirectoryOrCreate"
+  io-threads: "4"
+  worker-threads: "8"
+```
+
+`volumeBindingMode: Immediate` means PVCs bind immediately upon creation (without waiting for Pod scheduling). `path-type: DirectoryOrCreate` means each PVC corresponds to a directory on the Curvine file system — creation is far faster than solutions requiring cloud API calls.
+
+## III. 10,000-Pod Benchmark: Validating Scale Feasibility
+
+We conducted a scale validation test on Amazon EKS to answer one question: can Curvine reliably provide persistent storage for 10,000 independent stateful Pods on a production-grade EKS cluster?
+
+### 3.1 Test Environment
+
+| Parameter | Configuration |
+| --- | --- |
+| Region | us-west-2 |
+| Kubernetes Version | v1.31.14-eks |
+| Compute Nodes | 99 × r6g.4xlarge (Graviton ARM64, 16 vCPU, 128Gi RAM) |
+| Node Provisioning | Karpenter auto-scaling |
+| Network | VPC-CNI |
+
+### 3.2 Workload Configuration
+
+| Parameter | Value |
+| --- | --- |
+| Deployment | StatefulSet (`podManagementPolicy: Parallel`) |
+| Replicas | 10,000 |
+| Per-Pod Resources | 131m CPU / 1190Mi Memory (Guaranteed QoS) |
+| Per-Pod Storage | Independent PVC, 1Gi requested |
+| Per-Node Pod Density | ~100 Agent Pods + 2 system Pods |
+| Node Resource Utilization | CPU 88% / Memory 98% |
+
+### 3.3 Curvine Storage Cluster
+
+| Component | Count | Description |
+| --- | --- | --- |
+| Master | 1 | Metadata management |
+| Worker | 3 | Data cache service |
+| CSI Controller | 1 | Dynamic PVC provisioning |
+| CSI Node DaemonSet | 104 | One per node, handles FUSE mounts |
+| **Storage Cluster Total** | **109 Pods** | |
+
+The key number: the storage cluster serving 10,000 PVCs consists of only 1 Master + 3 Worker = 4 core Pods. The CSI Node DaemonSet is a lightweight mount agent that does not consume significant compute resources.
+
+### 3.4 Test Results
+
+**Provisioning Success Rate**
+
+- 10,000 PVCs: all Bound, zero Pending, zero Failed
+- 10,000 Pods: all Running, zero CrashLoopBackOff, zero storage-related errors
+
+**Storage Provisioning Specs**
+
+- Each PVC requested 1Gi, actually provisioned ~30Gi (Curvine's minimum allocation unit)
+- Total provisioned storage capacity: approximately 300TB
+- File system type: curvinefs (FUSE mount)
+
+**Data Durability Verification**
+
+- Wrote and verified data persistence on pod-0, pod-5000, and pod-9999
+- Data persisted after Pod restarts
+- Consistent file system view after cross-node rescheduling
+
+**Pod Distribution Uniformity**
+
+```
+102 pods × 98 nodes = 9,996 pods
+  4 pods ×  1 node  =     4 pods
+Total                = 10,000 pods
+```
+
+Each r6g.4xlarge node stably carried ~100 Agent Pods, with the CSI DaemonSet coexisting without resource contention.
+
+### 3.5 Storage View Inside Each Pod
+
+```
+Filesystem    Size      Used     Available  Use%  Mounted on
+curvinefs     29.8G     354.6M   29.5G      1%    /usr/share/nginx/html
+```
+
+Each Pod has an independent file system view, invisible to others — the same logical isolation as EBS, but bypassing EBS attachment count limits.
+
+### 3.6 Key Conclusions
+
+1. **Provisioning does not depend on cloud control plane APIs**: With EBS, creating a PVC triggers the CSI driver to call EBS `CreateVolume` and `AttachVolume` APIs. With EFS, it calls `CreateAccessPoint`. These cloud APIs have rate limits that cause queuing and slowdowns during mass concurrent creation. Curvine creates a PVC by essentially running `mkdir` on its own distributed file system — no cloud vendor API calls, fast and unconstrained by cloud API rate limits.
+2. **Minimal storage cluster resource overhead**: 4 core Pods serve tens of thousands of PVCs — no need to reserve large compute resources for the storage system itself.
+3. **Per-node Pod density no longer limited by storage**: 100 Pods share the same FUSE mount point at different paths, without EBS's 28/128 attachment ceiling.
+4. **Clear horizontal scaling path**: Add Worker nodes for greater scale or throughput without affecting existing PVCs.
+
+## IV. Getting Started
+
+If you are building an AI Agent platform on EKS and face any of these scenarios:
+
+- Each Agent instance needs an independent POSIX file system workspace
+- Total instances in the thousands to tens of thousands with rapid elastic scaling
+- High-density stateful Pods per node (>28)
+- Sensitive to small-file I/O latency (microseconds vs. milliseconds)
+
+Curvine is worth including in your storage technology evaluation.
+
+**Quick Start**
+
+- GitHub: [github.com/CurvineIO/curvine](https://github.com/CurvineIO/curvine)
+- Documentation: [curvineio.github.io](https://curvineio.github.io)
+- EKS Integration: Deploy Curvine cluster + CSI driver via Helm Chart, configure StorageClass, and start using
+
+Recommended validation path: start with 100–500 Pods to verify provisioning speed and I/O performance; if results meet expectations, gradually scale to thousands or tens of thousands. The storage cluster itself can start with 1 Master + 1 Worker, adding Worker nodes as needed to scale throughput and cache capacity.
+
+## Conclusion
+
+The "massive small-scale stateful instances" workload pattern brought by AI Agents poses new challenges for Kubernetes storage. EBS's per-instance attachment limits, EFS's provisioning bottlenecks, and S3's lack of POSIX semantics each fall short in different ways. Curvine, as a distributed cache file system designed for this scenario, validated on EKS that 10,000 independent PVCs can be provisioned and served reliably with minimal storage cluster overhead — providing a practical storage foundation for Agent platform scale-out.

--- a/i18n/zh-cn/docusaurus-plugin-content-blog/2026-07-07-ai-agent-storage-curvine-eks/index.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-blog/2026-07-07-ai-agent-storage-curvine-eks/index.md
@@ -1,0 +1,191 @@
+# AI Agent 存储选型：Curvine 如何在 EKS 上支撑万级Agent运行
+
+## 一、AI Agent 大规模部署的存储难题
+
+2026 年的 AI 基础设施正在经历一个根本性的架构转变：从"一个大模型实例服务所有请求"的中心化模式，走向"成千上万个 Agent 实例各自独立运行"的分布式模式。
+
+这不是概念上的变化。以使用 Vite 进行前端开发为例：Agent 在 debug 阶段需要运行 Vite 这类构建工具，Vite 的 dev server 依赖对项目 `node_modules` 和源码目录的高速随机读取来实现按需编译和模块热更新（HMR），开发者每次保存文件后期望在毫秒级看到页面变化，这对底层文件系统的小文件随机读性能和 `inotify`/`fswatch` 事件通知延迟都有很高要求。如果存储层跟不上，整个开发体验就会变得卡顿。
+
+每一个 Agent 实例都不是无状态的 HTTP handler，而是一个有独立工作目录、需要持久化存储的有状态进程。以 OpenClaw 这类 Agent 平台为例，OpenClaw 的整个记忆和协作系统建立在文件之上：`SOUL.md` 定义 Agent 的人格与行为边界，`AGENTS.md` 描述行为规则与会话工作流，`MEMORY.md` 存储跨会话的长期记忆，此外还有 `USER.md`、`TOOLS.md`、`HEARTBEAT.md` 等一组在启动时自动加载的 Markdown 文件，再加上项目源码、`node_modules`、`.git` 历史等。每个 Agent 实例运行在独立沙箱中，这些文件随时被读写和更新。当平台同时为数千个开发者分配各自的 Agent 实例时，就是典型的"万级独立文件系统"需求：每个实例需要隔离的 POSIX 工作空间，文件数量密集，且读写频繁。
+
+从 Kubernetes 的视角来看，这意味着你的集群需要同时支撑数千甚至上万个独立的 PersistentVolumeClaim。每个 PVC 都要能快速 provision，Agent 弹性扩缩容时不能等几分钟才拿到存储，同时要有低延迟的文件 I/O，并且在 Pod 被调度到其他节点后数据依然可达。
+
+这种"海量小规模有状态实例"的负载模式，和传统的数据库、消息队列等有状态应用完全不同。后者通常是少数几个大 PVC，前者是上万个小 PVC。亚马逊云科技原生的存储服务在面对这种新模式时，各自存在不同的优劣势。
+
+### 1.1 Amazon EBS：隔离性好，但挂载数是硬限制
+
+EBS 的优势在于隔离性。每个 Agent 一个独立的 EBS volume，性能互不干扰，故障也不会互相传染。对于需要严格租户隔离的场景，这是最干净的方案。
+
+但问题是：单个 EC2 实例能挂载的 EBS volume 数量有硬性上限。对于大部分 Nitro 实例（包括本次测试使用的 r6g 系列），最大 attachment 数为 28，这个数字还要和网络接口、NVMe instance store 共享。扣除主网卡后，实际可挂载的 EBS volume 大约在 27 个左右。第 7 代以后的部分实例类型（如 M7i、R7i 等）引入了独立的 EBS volume limit，根据实例大小不同有更高的配额，但对于 r6g 这类仍在 shared limit 下的实例，28 就是天花板。（参考：[Amazon EBS volume limits for Amazon EC2 instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/volume_limits.html)）
+
+这意味着什么？在我们的测试场景中，每台 r6g.4xlarge 节点跑了约 100 个 Agent Pod。如果用 EBS 给每个 Pod 分配独立 volume，一台节点最多挂 28 个，你需要将近 4 倍的节点数量才能承载相同的 Pod 密度，计算资源利用率直接从 88% 掉到 20% 左右。
+
+此外，EBS volume 绑定单个 AZ，无法跨 AZ 使用。一旦 Pod 被调度到其他 AZ 的节点上，原有的 EBS volume 就不可达，只能限制 Pod 调度到特定 AZ。对于需要跨 AZ 高可用和快速弹性伸缩的 Agent 平台来说，这是一个架构层面的硬约束。
+
+### 1.2 Amazon EFS：隔离机制成熟，但大规模 provision 是瓶颈
+
+EFS 作为托管的 NFS 文件系统，配合 Access Point 可以为每个 Agent 分配隔离的目录视图。每个 Access Point 有独立的 POSIX 权限和根目录，做到了文件系统级别的租户隔离。而且 EFS 支持 ReadWriteMany，Pod 跨节点调度后无需 detach/attach 操作，从调度灵活性的角度看很理想。自 2025 年 2 月起，单个 EFS 文件系统最多支持 10,000 个 Access Point，从配额上看足以覆盖万级 Agent 场景。
+
+然而在实际大规模部署中，瓶颈出现在 provision 速度上。当你通过 EFS CSI Driver 的动态 provisioning 同时创建数千个 PVC 时，每个 PVC 对应一个 Access Point 的创建。EFS API 对 Access Point 的创建有速率限制，CSI controller 需要串行或小批量地调用 API。
+
+### 1.3 Amazon S3：容量无限，但不是文件系统
+
+S3 的扩展性和成本效益毋庸置疑，作为 Agent 数据的最终归档层没有问题。但 Agent 运行时需要的是 POSIX 文件语义：`open`、`read`、`write`、`seek`、`rename`、`list directory` 这些操作。S3 是对象存储，不支持原地修改、不支持 rename 原子性、不支持目录列举的一致性语义。
+
+Mountpoint for Amazon S3 提供了 FUSE 挂载方案，但它明确声明只支持顺序写入新文件和读取已有文件，不支持随机写入和修改已有文件。对于需要反复修改 context 文件、append 日志、更新 checkpoint 的 Agent 工作流，这不是一个可行的运行时存储方案。
+
+## 二、Curvine：为 Agent 规模化设计的分布式缓存文件系统
+
+Curvine 是一个用 Rust 从头编写的高性能分布式缓存文件系统。名字来自"Curvature Engine"（曲率引擎），刘慈欣《三体》里的超光速推进装置，寓意对数据访问的极致加速。
+
+它的核心思路是：在云对象存储（如 S3）之上建立一层分布式文件系统缓存，向上提供完整的 POSIX 语义，向下以对象存储作为持久化层。对于 Kubernetes 工作负载，通过原生 CSI 驱动直接以 PVC 的方式挂载使用。
+
+### 2.1 核心架构
+
+Curvine 采用 Master-Worker 架构：
+
+- **Master 节点**：负责元数据管理、Worker 协调和负载均衡，使用 Raft 共识算法保证元数据的一致性和高可用
+- **Worker 节点**：负责实际的数据缓存和服务，支持内存、SSD、HDD 多层缓存，热数据自动提升到更快的层级
+- **客户端访问**：通过 FUSE 挂载提供 POSIX 文件系统接口；同时兼容 S3 和 HDFS 协议，可以对接现有的 AI/大数据生态
+
+在 Kubernetes 环境中，Curvine 以 CSI 驱动的形式集成：CSI Controller 处理 PVC 的动态 provisioning，CSI Node DaemonSet 在每个节点上运行，负责 FUSE 挂载。这意味着存储的 provision 过程不需要调用外部云 API，只是在分布式文件系统上创建一个目录，可以在毫秒级完成。
+
+### 2.2 为什么不是 JuiceFS
+
+JuiceFS 是这个领域的先行者，用 Go 实现，架构上也是"元数据引擎 + 对象存储"的模式。Curvine 和它的核心差异在于：
+
+- **性能层面**：Curvine 用 Rust 实现核心读写路径，多次使用零拷贝技术，官方标称 100μs 级延迟和 100K+ 稳定 QPS。Rust 的异步 runtime（tokio）加上无 GC 的内存模型，在高并发小文件场景下理论上比 Go 的 runtime 有优势
+- **元数据容量**：Curvine 宣称单集群支持 50 亿小文件，万级 Agent 各自产生的小文件聚合起来是很大的 metadata 压力
+- **元数据独立性**：Curvine 的文件元数据路径与底层 S3 的对象路径一一对应，即使 Curvine 服务出现问题，S3 上的文件依然保持原始结构、可独立访问，恢复起来很方便。而 JuiceFS 会将文件拆分成 Block 存储，从 S3 的对象名无法识别出原始文件，元数据的可用性强依赖 JuiceFS 服务本身
+- **缓存架构**：Curvine 原生支持内存 → SSD → HDD 的多层自动分级，JuiceFS 也有本地缓存能力，但 Curvine 在缓存调度策略上做得更细粒度
+- **定位差异**：JuiceFS 更侧重通用场景和云厂商的深度集成，Curvine 明确将 AI 训练加速和 Agent 云原生存储作为一级用例
+
+需要说明的是，这里并非要比较孰优孰劣。JuiceFS 与 Curvine 都是优秀的开源项目，在各自的设计目标下都做了大量工程优化，也都有活跃的社区。两者在架构取向上各有侧重，适用的场景也有所不同。具体选型应结合自身的工作负载特征、团队技术栈和运维偏好，通过实际测试来评估，本文不构成任何倾向性建议。
+
+### 2.3 CSI 集成方式
+
+在 EKS 上使用 Curvine 的 StorageClass 配置：
+
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: curvine-sc
+provisioner: curvine
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+allowVolumeExpansion: true
+parameters:
+  master-addrs: "curvine-master-0.curvine-master.curvine.svc.cluster.local:8995"
+  fs-path: "/k8s-volumes"
+  path-type: "DirectoryOrCreate"
+  io-threads: "4"
+  worker-threads: "8"
+```
+
+`volumeBindingMode: Immediate` 意味着 PVC 创建后立即绑定（不等 Pod 调度），`path-type: DirectoryOrCreate` 说明每个 PVC 对应的是 Curvine 文件系统上的一个目录，创建速度远快于需要调用云 API 的方案。
+
+## 三、万级 Pod 基准测试：验证规模化可行性
+
+我们在 Amazon EKS 上进行了一次规模验证测试，目标是回答一个问题：Curvine 能否在生产级 EKS 集群上，为 10,000 个独立的有状态 Pod 提供可靠的持久化存储？
+
+### 3.1 测试环境
+
+| 参数 | 配置 |
+| --- | --- |
+| Region | us-west-2 |
+| Kubernetes 版本 | v1.31.14-eks |
+| 计算节点 | 99 × r6g.4xlarge（Graviton ARM64，16 vCPU，128Gi RAM） |
+| 节点供给 | Karpenter 自动扩缩 |
+| 网络 | VPC-CNI |
+
+### 3.2 工作负载配置
+
+| 参数 | 数值 |
+| --- | --- |
+| 部署方式 | StatefulSet（`podManagementPolicy: Parallel`） |
+| 副本数 | 10,000 |
+| 每个 Pod 资源 | 131m CPU / 1190Mi Memory（Guaranteed QoS） |
+| 每个 Pod 存储 | 独立 PVC，1Gi requested |
+| 每节点 Pod 密度 | ~100 个 Agent Pod + 2 个系统 Pod |
+| 节点资源利用率 | CPU 88% / Memory 98% |
+
+### 3.3 Curvine 存储集群
+
+| 组件 | 数量 | 说明 |
+| --- | --- | --- |
+| Master | 1 | 元数据管理 |
+| Worker | 3 | 数据缓存服务 |
+| CSI Controller | 1 | 处理 PVC 动态 provisioning |
+| CSI Node DaemonSet | 104 | 每个节点一个，负责 FUSE 挂载 |
+| **存储集群总计** | **109 个 Pod** | |
+
+这里需要强调的数字是：支撑 10,000 个 PVC 的存储集群本身只有 1 Master + 3 Worker = 4 个核心 Pod。CSI Node DaemonSet 是轻量级的挂载代理，不消耗显著的计算资源。
+
+### 3.4 测试结果
+
+**供给成功率**
+
+- 10,000 个 PVC：全部 Bound，零 Pending，零 Failed
+- 10,000 个 Pod：全部 Running，零 CrashLoopBackOff，零存储相关错误
+
+**存储供给规格**
+
+- 每个 PVC requested 1Gi，实际 provisioned ~30Gi（Curvine 的最小分配单元）
+- 总 provisioned 存储容量：约 300TB
+- 文件系统类型：curvinefs（FUSE 挂载）
+
+**数据持久性验证**
+
+- 在 pod-0、pod-5000、pod-9999 上分别写入数据并验证持久化
+- Pod 重启后数据依然存在
+- 跨节点调度后文件系统视图一致
+
+**Pod 分布均匀性**
+
+```
+102 pods × 98 nodes = 9,996 pods
+  4 pods ×  1 node  =     4 pods
+Total                = 10,000 pods
+```
+
+每台 r6g.4xlarge 节点稳定承载 ~100 个 Agent Pod，CSI DaemonSet 与业务 Pod 共存无资源争抢。
+
+### 3.5 每个 Pod 内看到的存储
+
+```
+Filesystem    Size      Used     Available  Use%  Mounted on
+curvinefs     29.8G     354.6M   29.5G      1%    /usr/share/nginx/html
+```
+
+每个 Pod 拥有独立的文件系统视图，互相不可见，和 EBS 的逻辑隔离效果一致，但绕过了 EBS 的挂载数量限制。
+
+### 3.6 关键结论
+
+1. **Provision 不依赖云厂商控制平面 API**：使用 EBS 时，创建 PVC 会触发 CSI 驱动调用 EBS 的 CreateVolume、AttachVolume 接口；使用 EFS 则会调用 CreateAccessPoint。这些云 API 都有速率限制，大规模并发创建时会排队、变慢。而 Curvine 创建一个 PVC 本质上只是在它自己的分布式文件系统里 `mkdir` 一个目录，全程不调用任何云厂商 API，因此速度快、也不受云 API 限流的约束
+2. **存储集群的资源开销极小**：4 个核心 Pod 服务万级 PVC，不需要为存储系统本身预留大量计算资源
+3. **单节点 Pod 密度不再受存储限制**：100 个 Pod 共享同一个 FUSE 挂载点的不同路径，没有 EBS 那样的 28/128 上限
+4. **横向扩展路径清晰**：如果需要更大规模或更高吞吐，增加 Worker 节点即可，对已有 PVC 无影响
+
+## 四、试试看
+
+如果你正在 EKS 上构建 AI Agent 平台，面对的是以下任一场景：
+
+- 每个 Agent 实例需要独立的 POSIX 文件系统工作空间
+- 总实例数在千级到万级，且需要快速弹性伸缩
+- 单节点需要承载高密度的有状态 Pod（>28 个）
+- 对小文件 I/O 延迟敏感（微秒级 vs 毫秒级）
+
+那么 Curvine 值得纳入你的技术选型评估。
+
+**快速开始**
+
+- GitHub：[github.com/CurvineIO/curvine](https://github.com/CurvineIO/curvine)
+- 官方文档：[curvineio.github.io](https://curvineio.github.io)
+- EKS 集成：通过 Helm Chart 部署 Curvine 集群 + CSI 驱动，配置 StorageClass 后即可使用
+
+建议的验证路径：从 100–500 个 Pod 开始，验证 provision 速度和 I/O 表现；如果满足预期，再逐步放量到千级甚至万级。存储集群本身从 1 Master + 1 Worker 起步即可，按需增加 Worker 节点扩展吞吐和缓存容量。
+
+## 五、结语
+
+AI Agent 带来的"海量小规模有状态实例"负载模式，对 Kubernetes 存储提出了全新挑战。EBS 的单实例挂载数限制、EFS 的 provision 瓶颈、S3 缺乏 POSIX 语义，各自在不同维度上难以满足需求。Curvine 作为面向这一场景设计的分布式缓存文件系统，在 EKS 上验证了 10,000 个独立 PVC 可以被可靠供给和服务，且存储集群本身资源开销极小——为 Agent 平台的规模化扩展提供了切实可行的存储底座。


### PR DESCRIPTION
## Summary

- Add the AI Agent EKS storage blog post in English and Chinese
- Cover storage selection analysis, Curvine CSI integration, and the 10,000-Pod benchmark
- Remove outdated translation attribution lines from two existing English blog posts

## Test plan

-  `npm run build`
-  Verify English and Chinese blog page rendering