### PR TITLE
docs(transfer): document standalone load service (#1040)

### DIFF
--- a/docs/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/01-k8s-Deployment.md
+++ b/docs/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/01-k8s-Deployment.md
@@ -22,6 +22,8 @@ Helm release `curvine` is deployed in namespace `curvine`:
 | StatefulSet `curvine-worker` | Data nodes |
 | Service `curvine-master` | Headless, RPC 8995 |
 | Service `curvine-worker` | Headless, RPC 8997 |
+| Deployment `curvine-transfer` | Load / Export service, created only when enabled |
+| Service `curvine-transfer` | Internal Transfer RPC and web endpoint, created only when enabled |
 
 `openKruise.enabled` defaults to `false`. StatefulSets use `apps/v1`.
 
@@ -43,6 +45,40 @@ helm upgrade --install curvine curvine/curvine \
   --create-namespace \
   --wait --timeout 10m
 ```
+
+### Enable Transfer
+
+Use a Curvine image release that contains the Transfer binary. Do not use an
+older chart image tag just because the chart itself supports the values below.
+For production, MySQL must be reachable before the Transfer Pod starts:
+
+```yaml title="transfer-values.yaml"
+transfer:
+  enabled: true
+  storeUrl: "mysql://transfer_user:password@mysql.curvine.svc:3306/curvine_transfer"
+  replicas: 1
+```
+
+```bash
+helm upgrade --install curvine curvine/curvine \
+  -n curvine \
+  -f transfer-values.yaml \
+  --wait --timeout 10m
+```
+
+The chart creates `curvine-transfer` as an internal `ClusterIP` Service and
+writes its Service FQDN to `[transfer].hostname`. Curvine infers the RPC
+endpoint from that hostname and `transfer.rpcPort`; do not configure
+`endpoints` in normal Helm deployments.
+
+An empty `transfer.storeUrl` is a single-Pod SQLite development default. It
+uses an `emptyDir`, so it survives only container restarts in the same Pod. Use
+MySQL for production, and MySQL is mandatory when `transfer.replicas > 1`.
+
+The generated ConfigMap is used by Master, Worker, and Transfer. External CLI
+hosts must also use a cluster config with `[transfer] enabled = true`; the CLI
+commands remain `cv load`, `cv export`, `cv load-status`, and
+`cv cancel-load`.
 
 ### Verify
 
@@ -207,6 +243,20 @@ Set `openKruise.enabled=true` to install the kruise subchart and switch master/w
 | `worker.tolerations` | `[]` | Tolerations |
 | `worker.affinity` | `{}` | Affinity rules |
 
+### Transfer
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `transfer.enabled` | `false` | Creates no Transfer resources until enabled; disabled mode preserves the legacy Master Load API. |
+| `transfer.storeUrl` | `""` | Empty infers local SQLite. Use `mysql://...` for durable production storage. |
+| `transfer.replicas` | `1` | Transfer Pod replicas. Values greater than one require a MySQL `storeUrl`. |
+| `transfer.rpcPort` | `9010` | Transfer RPC Service and container port. |
+| `transfer.webPort` | `9011` | Transfer `/healthz`, `/readyz`, and `/metrics` port. |
+| `transfer.resources.requests.cpu` | `500m` | CPU request. |
+| `transfer.resources.requests.memory` | `1Gi` | Memory request. |
+| `transfer.resources.limits.cpu` | `1000m` | CPU limit. |
+| `transfer.resources.limits.memory` | `2Gi` | Memory limit. |
+
 ### Service
 
 | Parameter | Default | Description |
@@ -249,6 +299,7 @@ Override individual TOML sections without replacing the full config:
 | `configOverrides.journal` | `{}` | Journal section overrides |
 | `configOverrides.worker` | `{}` | Worker section overrides |
 | `configOverrides.client` | `{}` | Client section overrides |
+| `configOverrides.transfer` | `{}` | Additional public `[transfer]` settings such as `max_running_transfers`, `lease_timeout`, and `terminal_retention`. Chart-managed `enabled`, `hostname`, ports, and `store_url` cannot be overridden here. |
 | `configOverrides.log` | `{}` | Log section overrides |
 
 ### Storage modes

--- a/docs/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/03-conf.md
+++ b/docs/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/03-conf.md
@@ -37,7 +37,8 @@ The current `ClusterConf` contains these main sections:
 | `[fuse]` | FUSE mount and cache settings |
 | `[log]` | Global client / FUSE log settings |
 | `[s3_gateway]` | S3-compatible gateway settings |
-| `[job]` | Load-job lifecycle and concurrency settings |
+| `[job]` | Legacy Master load-job lifecycle and concurrency settings |
+| `[transfer]` | Standalone Load / Export service configuration |
 | `[cli]` | CLI log settings |
 
 :::warning
@@ -213,6 +214,78 @@ Important FUSE defaults from `FuseConf`:
 | `check_permission` | `true` | Enforce permission checks |
 | `list_limit` | `1000` | Directory listing limit |
 
+## `[transfer]`
+
+Transfer separates Load and Export orchestration from Master. It is disabled by
+default, so an existing cluster continues to use the legacy Master Load API
+unchanged. When enabled, `cv load`, `cv export`, `cv load-status`, and
+`cv cancel-load` keep the same syntax but call Transfer directly.
+
+There is no Master-side redirect. The Master rejects a legacy Load / Export
+submission after it has been switched to Transfer mode, because accepting both
+paths would create two independent job owners. Therefore Master, Worker,
+Transfer, and external CLI hosts must use the same `[transfer]` setting during
+the cutover.
+
+### Required production settings
+
+For a single local development process, `enabled = true` is enough: Curvine
+infers a local SQLite database. Production requires a reachable MySQL URL:
+
+```toml
+[transfer]
+enabled = true
+store_url = "mysql://transfer_user:password@mysql.example:3306/curvine_transfer"
+```
+
+Do not place a production password in source control. Distribute the same
+runtime configuration through the deployment system already used for the
+cluster and for CLI hosts.
+
+### Start and cut over
+
+For a package or bare-metal deployment, install a Curvine version containing
+the Transfer binary on the service host, then use the normal cluster config:
+
+```bash
+bin/curvine-transfer.sh start
+```
+
+Cut over in this order:
+
+1. Make MySQL reachable and add `[transfer]` to the shared cluster config.
+2. Start Transfer and wait for its RPC and web endpoints to become ready.
+3. Restart Master and Worker so they read `transfer.enabled = true`.
+4. Distribute the same config to CLI hosts, then submit with normal `cv load`
+   or `cv export` commands.
+
+Pause new Load / Export submissions while steps 2-4 are in progress. A CLI
+that still has `enabled = false` after Master has switched reports a clear
+legacy-API-disabled error; it is not silently redirected.
+
+### Parameters
+
+Only the following fields are operator configuration. Time values use Curvine
+duration syntax such as `90s`, `24h`, and `168h`.
+
+| Field | Default | Meaning |
+| --- | --- | --- |
+| `enabled` | `false` | Enables Transfer mode. `false` preserves the legacy Master Load / Export path. |
+| `store_url` | `sqlite://data/transfer/transfer.db` after inference | Job metadata store. Use `mysql://...` for durable production operation and for more than one Transfer replica. |
+| `hostname` | `localhost` | Advertised Transfer hostname. In Kubernetes the chart sets the internal Service DNS automatically. |
+| `rpc_port` | `9010` | Transfer RPC port. |
+| `web_port` | `9011` | Transfer web endpoint for `/healthz`, `/readyz`, and `/metrics`. |
+| `endpoints` | `[]` | Client RPC endpoints. Empty automatically becomes `hostname:rpc_port`; normally leave it empty. |
+| `instance_id` | empty | Lease owner ID. Empty generates a unique ID on each Transfer process start. |
+| `cv_metadata_reader` | `auto` | Resolves to the metadata replica reader. A MySQL production store requires this effective value to be `replica`. |
+| `max_running_transfers` | `64` | Maximum transfers allowed to run concurrently. |
+| `lease_timeout` | `120s` | Lease duration used to recover work from a lost Transfer instance. |
+| `terminal_retention` | `168h` | Retention period for completed, failed, or canceled transfer records. |
+
+`store_type`, `sqlite_path`, and `mysql_url` are compatibility inputs from an
+earlier configuration shape. Use `store_url`; it determines the store type from
+the URI and needs no separate selector.
+
 ## `[log]`, `[cli]`, `[job]`, `[s3_gateway]`
 
 ### Global `[log]`
@@ -224,6 +297,10 @@ The top-level `[log]` section is the shared client/FUSE log config. In the sampl
 `CliConf` is intentionally small: it currently contains only `log`, and the default CLI log level is `warn`.
 
 ### `[job]`
+
+`[job]` configures the legacy Master job implementation used while
+`transfer.enabled = false`. After the Transfer cutover, job ownership,
+recovery, and retention use `[transfer]` instead.
 
 Important job defaults from `JobConf`:
 
@@ -277,6 +354,9 @@ master_addrs = [
   { hostname = "master2", port = 8995 },
   { hostname = "master3", port = 8995 },
 ]
+
+[transfer]
+enabled = false
 
 [fuse]
 mnt_path = "/curvine-fuse"

--- a/docs/3-User-Manuals/1-Key-Features/02-cache.md
+++ b/docs/3-User-Manuals/1-Key-Features/02-cache.md
@@ -99,7 +99,7 @@ The current read-side validation control is `--read-verify-ufs` on the mount:
 | disabled | Cached data is trusted and normal unified filesystem fallback rules apply. |
 | enabled | On reads, Curvine compares cached file metadata against UFS (`mtime` and file length) before serving cached data. |
 
-When validation fails, or when the cache misses, data is read directly from UFS. If automatic caching is enabled for that mount, Curvine can also submit a background load job.
+When validation fails, or when the cache misses, data is read directly from UFS. If automatic caching is enabled for that mount, Curvine can also submit a background load job. With `[transfer] enabled = true`, that job is owned by the standalone Transfer service; otherwise it uses the legacy Master job path.
 
 ## 7. Data Expiration Management (TTL)
 
@@ -198,7 +198,7 @@ If `ttl_action = "none"` is configured, disabling time-based expiration, the dat
 
 ### 9.1 Automatic Caching
 
-Automatic caching is enabled for a mount when that mount has a non-zero TTL, for example `cv mount s3://bucket/prefix /path --ttl-ms 7d`. On the first read of a UFS file under that mount, Curvine submits an asynchronous load job to bring the data into Curvine. The read is served from UFS while the job runs in the background.
+Automatic caching is enabled for a mount when that mount has a non-zero TTL, for example `cv mount s3://bucket/prefix /path --ttl-ms 7d`. On the first read of a UFS file under that mount, Curvine submits an asynchronous load job to bring the data into Curvine. The read is served from UFS while the job runs in the background. The job follows the same Transfer routing as a manual `cv load` command.
 
 Example log output:
 
@@ -209,7 +209,7 @@ Submit async cache successfully for s3://bucket/cache/test.log, job res CacheJob
 Use the `job_id` to query the caching task status:
 
 ```plain
-bin/cv load-status 7c00853f-13c8-43c1-8b3f-44740750b5a0
+cv load-status 7c00853f-13c8-43c1-8b3f-44740750b5a0
 ```
 
 ### 9.2 Proactive Caching
@@ -217,10 +217,12 @@ bin/cv load-status 7c00853f-13c8-43c1-8b3f-44740750b5a0
 You can proactively load UFS data into Curvine using the `load` command:
 
 ```plain
-bin/cv load s3://bucket/cache/test.log
+cv load s3://bucket/cache/test.log
 ```
 
 Automatic caching and proactive caching are not mutually exclusive. Proactive caching can reduce the time required for the first read of a UFS file.
+
+When Transfer is enabled, use `cv transfer list` and `cv transfer status <job_id>` for job-wide operations. `cv load-status` remains the compatible status command.
 
 :::tip
 Before loading data, the UFS must first be mounted to Curvine with `cv mount`.

--- a/docs/3-User-Manuals/2-Operations/02-cli.md
+++ b/docs/3-User-Manuals/2-Operations/02-cli.md
@@ -1,6 +1,6 @@
 # Command Line Tools
 
-This section is based on the current repository source in `curvine-cli`, `build/bin/cv`, and `build/bin/dfs`. Curvine currently exposes three CLI entry styles:
+This section is based on the current repository source in `curvine-cli`, `build/cv`, and `build/bin/dfs`. Curvine currently exposes three CLI entry styles:
 
 - **Native Rust CLI `cv`**: the recommended entry point, with the full command tree from `curvine-cli`.
 - **Compatibility wrapper `dfs`**: bundled in the distribution; `fs` / `report` go through Java `CurvineShell` and keep Hadoop `FsShell` style.
@@ -25,8 +25,10 @@ Commands:
   fs
   report
   load
+  export
   load-status
   cancel-load
+  transfer
   mount
   umount
   node
@@ -37,16 +39,19 @@ All `cv` commands accept these global options:
 
 | Global option | Description |
 |---------------|-------------|
-| `-c, --conf <PATH>` | Cluster config file path. If omitted, the CLI also checks `CURVINE_CONF_FILE`. |
+| `-c, --conf <PATH>` | Override the cluster config file for this invocation. If omitted, the CLI uses its normal configured path or `CURVINE_CONF_FILE`. |
 | `--master-addrs <ADDRS>` | Override the client-side master address list directly, for example `m1:8995,m2:8995`. |
 
 :::tip
-To avoid ambiguity, this doc always uses `--conf` for the CLI config file and `--config key=value` for UFS mount properties. Do not rely on short `-c` inside `mount`.
+Normal production commands use `cv` directly because the cluster configuration
+is already installed or selected through `CURVINE_CONF_FILE`. Use `--conf` only
+to select a non-default configuration, for example during migration or
+diagnosis. `cv mount --config key=value` remains the UFS-property option.
 :::
 
 **Conventions:**
 
-- In the distribution, the CLI is usually invoked as `build/dist/bin/cv`.
+- In production, add the distribution `bin/` directory to `PATH` and invoke `cv` directly.
 - When run via `cargo run -p curvine-cli -- ...`, the help output shows the binary name as `curvine-cli`.
 - Items such as `<PATH>` and `<JOB_ID>` are positional arguments; `[OPTION]` means optional.
 
@@ -68,13 +73,13 @@ To avoid ambiguity, this doc always uses `--conf` for the CLI config file and `-
 Examples:
 
 ```bash
-bin/cv report
-bin/cv report json
-bin/cv report all --show-workers false
-bin/cv report capacity
-bin/cv report capacity 192.168.1.10
-bin/cv report used
-bin/cv report available
+cv report
+cv report json
+cv report all --show-workers false
+cv report capacity
+cv report capacity 192.168.1.10
+cv report used
+cv report available
 ```
 
 :::note
@@ -101,10 +106,10 @@ In the current implementation, `cv report capacity <WORKER_ADDRESS>` matches by 
 Examples:
 
 ```bash
-bin/cv node -l
-bin/cv node --add-decommission host1:8997 host2:8997
-bin/cv node --add-decommission host1:8997,host2:8997
-bin/cv node --remove-decommission host1:8997
+cv node -l
+cv node --add-decommission host1:8997 host2:8997
+cv node --add-decommission host1:8997,host2:8997
+cv node --remove-decommission host1:8997
 ```
 
 :::note
@@ -147,21 +152,21 @@ The current source exposes these `fs` subcommands:
 Common examples:
 
 ```bash
-bin/cv fs ls /
-bin/cv fs ls / --cache-only
-bin/cv fs mkdir -p /data/a/b
-bin/cv fs put ./local.txt /data/remote.txt
-bin/cv fs get /data/remote.txt ./local.txt
-bin/cv fs cat /data/remote.txt
-bin/cv fs stat /data
-bin/cv fs count /data
-bin/cv fs mv /data/a /data/b
-bin/cv fs du -h /data
-bin/cv fs df -h
-bin/cv fs chmod 755 /data/script.sh
-bin/cv fs chown user:group /data
-bin/cv fs blocks /data/file.txt --format json
-bin/cv fs free /data --recursive
+cv fs ls /
+cv fs ls / --cache-only
+cv fs mkdir -p /data/a/b
+cv fs put ./local.txt /data/remote.txt
+cv fs get /data/remote.txt ./local.txt
+cv fs cat /data/remote.txt
+cv fs stat /data
+cv fs count /data
+cv fs mv /data/a /data/b
+cv fs du -h /data
+cv fs df -h
+cv fs chmod 755 /data/script.sh
+cv fs chown user:group /data
+cv fs blocks /data/file.txt --format json
+cv fs free /data --recursive
 ```
 
 `cv fs ls` also supports HDFS-style listing flags:
@@ -231,13 +236,13 @@ Examples:
 
 ```bash
 # List mount points
-bin/cv mount
+cv mount
 
 # List mount points and validate UFS availability
-bin/cv mount --check
+cv mount --check
 
 # Create an S3 mount
-bin/cv mount s3://bucket/datasets /bucket/datasets \
+cv mount s3://bucket/datasets /bucket/datasets \
   --config s3.endpoint_url=http://hostname.com \
   --config s3.region_name=cn \
   --config s3.credentials.access=access_key \
@@ -246,13 +251,13 @@ bin/cv mount s3://bucket/datasets /bucket/datasets \
   --provider opendal
 
 # Create an OSS mount through JindoSDK / OSS-HDFS
-bin/cv mount oss://my-bucket/prefix /oss-data --provider oss-hdfs \
+cv mount oss://my-bucket/prefix /oss-data --provider oss-hdfs \
   --config oss.endpoint=oss-cn-hangzhou.aliyuncs.com \
   --config oss.accessKeyId=xxx \
   --config oss.accessKeySecret=yyy
 
 # Run a metadata resync manually
-bin/cv mount resync /bucket/datasets --dry-run --verbose
+cv mount resync /bucket/datasets --dry-run --verbose
 ```
 
 For detailed parameter lists of each UFS type (S3, OSS, HDFS, WebHDFS), see [Appendix: UFS Mount Parameters](#appendix-ufs-mount-parameters) at the end.
@@ -274,7 +279,7 @@ In the current source, the first creation of an `fs_mode` mount automatically tr
 Example:
 
 ```bash
-bin/cv umount /bucket/datasets
+cv umount /bucket/datasets
 ```
 
 ---
@@ -287,20 +292,54 @@ bin/cv umount /bucket/datasets
 |-------------------|-------------|
 | `<PATH>` | Source path to load. In practice this is usually a UFS path that already belongs to a mount. |
 | `-w, --watch` | Watch job status immediately after submission. |
-| `--conf <PATH>` | CLI config file. |
+| `--conf <PATH>` | Optional one-command config override; normal use does not need it. |
 
 Examples:
 
 ```bash
-bin/cv load s3://bucket/datasets/train/part-0001.parquet
-bin/cv load s3://bucket/datasets/train/part-0001.parquet --watch
+cv load s3://bucket/datasets/train/part-0001.parquet
+cv load s3://bucket/datasets/train/part-0001.parquet --watch
 ```
 
 On success, the command prints `job_id` and `target_path`, which can then be used with `load-status` or `cancel-load`.
 
+#### Transfer routing
+
+The command line does not change when standalone Transfer is enabled:
+
+| Cluster configuration | `cv load` / `cv export` route |
+| --- | --- |
+| `[transfer] enabled = false` | Legacy Master Load API, for backward compatibility. |
+| `[transfer] enabled = true` | Transfer service RPC, selected directly by the CLI. |
+
+The Master does not proxy legacy submissions to Transfer. During a cutover, make
+sure the CLI has the same `[transfer]` configuration as the cluster; a stale
+CLI config is rejected rather than creating a second job owner.
+
 ---
 
-### 7. `load-status`: query job status
+### 7. `export`: export a Curvine path to UFS
+
+**Usage:** `cv export [OPTIONS] <PATH>`
+
+`<PATH>` must be a Curvine path below a mount. Curvine infers the UFS target
+from that mount.
+
+| Option / Argument | Description |
+|-------------------|-------------|
+| `<PATH>` | Curvine source path to export. |
+| `-w, --watch` | Watch job status immediately after submission. |
+| `--no-overwrite` | Fail when the UFS target already exists. |
+
+Example:
+
+```bash
+cv export /bucket/datasets/train/part-0001.parquet --watch
+```
+
+---
+
+### 8. `load-status`: query job status
 
 **Usage:** `cv load-status [OPTIONS] <JOB_ID>`
 
@@ -309,13 +348,13 @@ On success, the command prints `job_id` and `target_path`, which can then be use
 | `<JOB_ID>` | Load job identifier. |
 | `-v, --verbose` | Verbose output. |
 | `-w, --watch <INTERVAL>` | Poll interval, default `5s`. Supports formats such as `1s`, `1m`, and `1h`. |
-| `--conf <PATH>` | CLI config file. |
+| `--conf <PATH>` | Optional one-command config override; normal use does not need it. |
 
 Examples:
 
 ```bash
-bin/cv load-status <job_id>
-bin/cv load-status <job_id> -w 1s
+cv load-status <job_id>
+cv load-status <job_id> -w 1s
 ```
 
 :::note
@@ -324,31 +363,60 @@ In the current implementation, `load-status` enters watch mode by default with a
 
 ---
 
-### 8. `cancel-load`: cancel a load job
+### 9. `cancel-load`: cancel a load job
 
 **Usage:** `cv cancel-load [OPTIONS] <JOB_ID>`
 
 | Option / Argument | Description |
 |-------------------|-------------|
 | `<JOB_ID>` | Job identifier to cancel. |
-| `--conf <PATH>` | CLI config file. |
+| `--conf <PATH>` | Optional one-command config override; normal use does not need it. |
 
 Example:
 
 ```bash
-bin/cv cancel-load <job_id>
+cv cancel-load <job_id>
 ```
 
 ---
 
-### 9. `version`: show version
+### 10. `transfer`: operate Transfer jobs
+
+`cv transfer` is available only when `[transfer] enabled = true`. It is the
+operations command for listing, inspecting, retrying, and paging Transfer jobs;
+normal submission remains `cv load` or `cv export`.
+
+| Command | Description |
+| --- | --- |
+| `cv transfer list` | List jobs. Filter with `--kind load\|export`, `--state`, `--tenant`, or `--submitter`. |
+| `cv transfer status <JOB_ID>` | Show one job. Add `--verbose` for task detail or `--watch --interval 1s` to poll. |
+| `cv transfer tasks <JOB_ID>` | Show a task page for one job. |
+| `cv transfer cancel <JOB_ID>` | Cancel a Transfer job. |
+| `cv transfer retry <JOB_ID>` | Retry a failed, canceled, or partially successful job as a new job. |
+| `cv transfer tenants` | Summarize jobs by tenant. |
+
+Examples:
+
+```bash
+cv transfer list --kind load --state running
+cv transfer status <job_id> --watch --interval 2s
+cv transfer retry <job_id>
+```
+
+`load-status` and `cancel-load` remain compatible shortcuts. With Transfer
+enabled, they call Transfer; with Transfer disabled, they call the legacy
+Master implementation.
+
+---
+
+### 11. `version`: show version
 
 **Usage:** `cv version`
 
 Example:
 
 ```bash
-bin/cv version
+cv version
 ```
 
 The current implementation prints `curvine-cli <version>` together with commit / branch information.

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/01-k8s-Deployment.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/01-k8s-Deployment.md
@@ -22,6 +22,8 @@ Helm release `curvine` 部署于 namespace `curvine`：
 | StatefulSet `curvine-worker` | 数据节点 |
 | Service `curvine-master` | Headless，RPC 8995 |
 | Service `curvine-worker` | Headless，RPC 8997 |
+| Deployment `curvine-transfer` | Load / Export 服务，仅在启用时创建 |
+| Service `curvine-transfer` | 集群内 Transfer RPC 与 Web 端点，仅在启用时创建 |
 
 默认 `openKruise.enabled=false`，StatefulSet 使用 `apps/v1`。
 
@@ -43,6 +45,30 @@ helm upgrade --install curvine curvine/curvine \
   --create-namespace \
   --wait --timeout 10m
 ```
+
+### 启用 Transfer
+
+使用包含 Transfer 二进制的 Curvine 镜像版本；不要只因 Chart 支持以下参数就使用较旧的镜像 tag。生产环境必须先保证 MySQL 可达，再启动 Transfer Pod：
+
+```yaml title="transfer-values.yaml"
+transfer:
+  enabled: true
+  storeUrl: "mysql://transfer_user:password@mysql.curvine.svc:3306/curvine_transfer"
+  replicas: 1
+```
+
+```bash
+helm upgrade --install curvine curvine/curvine \
+  -n curvine \
+  -f transfer-values.yaml \
+  --wait --timeout 10m
+```
+
+Chart 会创建仅集群内可见的 `curvine-transfer` `ClusterIP` Service，并将其 FQDN 写入 `[transfer].hostname`。Curvine 根据该 hostname 和 `transfer.rpcPort` 自动推导 RPC 地址；常规 Helm 部署不要配置 `endpoints`。
+
+`transfer.storeUrl` 为空时使用单 Pod SQLite 开发默认值，数据位于 `emptyDir`，只会跨同一 Pod 内的容器重启保留。生产环境使用 MySQL；`transfer.replicas > 1` 时 MySQL 是必需的。
+
+生成的 ConfigMap 同时供 Master、Worker 和 Transfer 使用。集群外 CLI 主机也必须使用 `[transfer] enabled = true` 的集群配置；客户端命令仍是 `cv load`、`cv export`、`cv load-status` 和 `cv cancel-load`。
 
 ### 验证
 
@@ -141,6 +167,20 @@ Chart 版本 `0.3.2-alpha`。下表默认值与 `helm show values curvine/curvin
 | `openKruise.persistentPodState.requiredPersistentTopology` | `""` | 强制拓扑键（可选） |
 | `kruise.installation.namespace` | `kruise-system` | Kruise 子 chart 命名空间（启用时） |
 | `kruise.installation.createNamespace` | `true` | 创建 Kruise 命名空间 |
+
+### Transfer
+
+| 参数 | 默认值 | 说明 |
+|-----------|---------|-------------|
+| `transfer.enabled` | `false` | 未启用时不创建 Transfer 资源；关闭时保持旧 Master Load API。 |
+| `transfer.storeUrl` | `""` | 空值自动推导本地 SQLite。生产持久化存储使用 `mysql://...`。 |
+| `transfer.replicas` | `1` | Transfer Pod 副本数。大于 1 时必须使用 MySQL `storeUrl`。 |
+| `transfer.rpcPort` | `9010` | Transfer RPC Service 与容器端口。 |
+| `transfer.webPort` | `9011` | Transfer `/healthz`、`/readyz`、`/metrics` 端口。 |
+| `transfer.resources.requests.cpu` | `500m` | CPU request。 |
+| `transfer.resources.requests.memory` | `1Gi` | 内存 request。 |
+| `transfer.resources.limits.cpu` | `1000m` | CPU limit。 |
+| `transfer.resources.limits.memory` | `2Gi` | 内存 limit。 |
 
 ### Master
 
@@ -249,6 +289,7 @@ Chart 版本 `0.3.2-alpha`。下表默认值与 `helm show values curvine/curvin
 | `configOverrides.journal` | `{}` | Journal 段覆盖 |
 | `configOverrides.worker` | `{}` | Worker 段覆盖 |
 | `configOverrides.client` | `{}` | Client 段覆盖 |
+| `configOverrides.transfer` | `{}` | `[transfer]` 额外公开配置，如 `max_running_transfers`、`lease_timeout`、`terminal_retention`。Chart 管理的 `enabled`、`hostname`、端口和 `store_url` 不能在此覆盖。 |
 | `configOverrides.log` | `{}` | Log 段覆盖 |
 
 ### 存储方式

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/03-conf.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/03-conf.md
@@ -37,7 +37,8 @@ Curvine 常见的配置输入包括：
 | `[fuse]` | FUSE 挂载与缓存参数 |
 | `[log]` | 全局 client / fuse 日志 |
 | `[s3_gateway]` | S3 兼容网关配置 |
-| `[job]` | load 任务生命周期与并发控制 |
+| `[job]` | 旧 Master load 任务的生命周期与并发控制 |
+| `[transfer]` | 独立的 Load / Export 服务配置 |
 | `[cli]` | CLI 日志配置 |
 
 :::warning
@@ -213,6 +214,61 @@ data_dir = [
 | `check_permission` | `true` | 是否执行权限检查 |
 | `list_limit` | `1000` | 目录列举数量限制 |
 
+## `[transfer]`
+
+Transfer 将 Load 和 Export 的编排从 Master 中独立出来。默认关闭，因此已有集群继续使用旧 Master Load API，不改变原有行为。开启后，`cv load`、`cv export`、`cv load-status` 和 `cv cancel-load` 命令不变，但会由 CLI 直接调用 Transfer。
+
+Master 不会将旧 Load / Export 请求转发给 Transfer。切换到 Transfer 模式后，Master 会拒绝旧请求，因为同时接受两条路径会产生两个独立的任务所有者。因此切换时，Master、Worker、Transfer 和集群外的 CLI 都必须使用相同的 `[transfer]` 配置。
+
+### 生产环境必填配置
+
+单进程本地开发只需设置 `enabled = true`，Curvine 会推导本地 SQLite。生产环境需要一个可连接的 MySQL URL：
+
+```toml
+[transfer]
+enabled = true
+store_url = "mysql://transfer_user:password@mysql.example:3306/curvine_transfer"
+```
+
+不要将生产密码写入源码。通过现有的部署系统向集群和 CLI 主机分发同一份运行时配置。
+
+### 启动与切换
+
+包部署或裸机部署时，在服务主机安装包含 Transfer 二进制的 Curvine 版本，然后使用集群的正常配置启动：
+
+```bash
+bin/curvine-transfer.sh start
+```
+
+按以下顺序切换：
+
+1. 确保 MySQL 可达，并在共享集群配置中加入 `[transfer]`。
+2. 启动 Transfer，等待其 RPC 与 Web 端点就绪。
+3. 重启 Master 和 Worker，使其读取 `transfer.enabled = true`。
+4. 向 CLI 主机分发同一份配置，然后仍通过普通 `cv load` 或 `cv export` 提交任务。
+
+执行步骤 2 至 4 时暂停新的 Load / Export 提交。若 Master 已切换而 CLI 仍使用 `enabled = false`，会收到清晰的旧 API 已禁用错误，不会被静默转发。
+
+### 参数
+
+以下是运维需要配置的字段。时长使用 Curvine 格式，例如 `90s`、`24h` 和 `168h`。
+
+| 字段 | 默认值 | 含义 |
+| --- | --- | --- |
+| `enabled` | `false` | 启用 Transfer 模式。`false` 保留旧 Master Load / Export 路径。 |
+| `store_url` | 推导后为 `sqlite://data/transfer/transfer.db` | 任务元数据存储。生产环境和多副本 Transfer 使用 `mysql://...`。 |
+| `hostname` | `localhost` | 对外声明的 Transfer 主机名。Kubernetes Chart 会自动设置为集群内 Service DNS。 |
+| `rpc_port` | `9010` | Transfer RPC 端口。 |
+| `web_port` | `9011` | 提供 `/healthz`、`/readyz`、`/metrics` 的 Web 端口。 |
+| `endpoints` | `[]` | 客户端 RPC 地址。为空时自动推导为 `hostname:rpc_port`，通常保持为空。 |
+| `instance_id` | 空 | 租约所有者 ID。为空时每个 Transfer 进程启动自动生成唯一 ID。 |
+| `cv_metadata_reader` | `auto` | 实际使用元数据副本读取器。MySQL 生产存储要求其生效值为 `replica`。 |
+| `max_running_transfers` | `64` | 同时运行的 Transfer 最大数量。 |
+| `lease_timeout` | `120s` | 用于从失联 Transfer 实例恢复任务的租约时长。 |
+| `terminal_retention` | `168h` | 已完成、失败或取消任务记录的保留时间。 |
+
+`store_type`、`sqlite_path` 和 `mysql_url` 是早期配置形态的兼容输入。新配置只使用 `store_url`，存储类型由 URI 自动推导，不需要单独指定。
+
 ## `[log]`、`[cli]`、`[job]`、`[s3_gateway]`
 
 ### 全局 `[log]`
@@ -224,6 +280,8 @@ data_dir = [
 `CliConf` 目前非常精简，只包含 `log`；CLI 默认日志级别为 `warn`。
 
 ### `[job]`
+
+`[job]` 用于 `transfer.enabled = false` 时的旧 Master 任务实现。切换到 Transfer 后，任务所有权、恢复和保留策略由 `[transfer]` 控制。
 
 `JobConf` 中关键默认值：
 
@@ -277,6 +335,9 @@ master_addrs = [
   { hostname = "master2", port = 8995 },
   { hostname = "master3", port = 8995 },
 ]
+
+[transfer]
+enabled = false
 
 [fuse]
 mnt_path = "/curvine-fuse"

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/3-User-Manuals/1-Key-Features/02-cache.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/3-User-Manuals/1-Key-Features/02-cache.md
@@ -99,7 +99,7 @@ storage_type = "mem"
 | 关闭 | 信任缓存与统一文件系统默认回退逻辑。 |
 | 开启 | 读前按 UFS 元数据（`mtime` 与文件长度）校验缓存。 |
 
-当校验失败或缓存未命中时，会直接从 UFS 读取；若该挂载启用了自动缓存，可同时异步将数据加载到 Curvine。
+当校验失败或缓存未命中时，会直接从 UFS 读取；若该挂载启用了自动缓存，可同时异步将数据加载到 Curvine。`[transfer] enabled = true` 时，该任务由独立 Transfer 服务负责；否则仍使用旧 Master 任务路径。
 
 ## 七、数据过期管理（TTL）
 
@@ -198,7 +198,7 @@ quota_eviction_high_rate = 0.8
 
 ### 9.1 自动缓存
 
-当某挂载配置了非零 TTL（例如 `cv mount s3://bucket/prefix /path --ttl-ms 7d`）时，即启用该挂载的自动缓存。在该挂载下首次读取某个 UFS 文件（缓存未命中）时，Curvine 会提交一个异步加载任务，将数据拉取到 Curvine；本次读取由 UFS 直接返回，任务在后台执行。
+当某挂载配置了非零 TTL（例如 `cv mount s3://bucket/prefix /path --ttl-ms 7d`）时，即启用该挂载的自动缓存。在该挂载下首次读取某个 UFS 文件（缓存未命中）时，Curvine 会提交一个异步加载任务，将数据拉取到 Curvine；本次读取由 UFS 直接返回，任务在后台执行。该任务与手工 `cv load` 使用相同的 Transfer 路由规则。
 
 在日志中可看到类似输出：
 
@@ -209,7 +209,7 @@ Submit async cache successfully for s3://bucket/cache/test.log, job res CacheJob
 可用 `job_id` 查询缓存任务状态：
 
 ```plain
-bin/cv load-status 7c00853f-13c8-43c1-8b3f-44740750b5a0
+cv load-status 7c00853f-13c8-43c1-8b3f-44740750b5a0
 ```
 
 ### 9.2 主动缓存
@@ -217,10 +217,12 @@ bin/cv load-status 7c00853f-13c8-43c1-8b3f-44740750b5a0
 可以使用 `load` 命令主动加载 UFS 数据到 Curvine，示例如下：
 
 ```plain
-bin/cv load s3://bucket/cache/test.log
+cv load s3://bucket/cache/test.log
 ```
 
 自动缓存与主动缓存可同时使用；主动缓存可缩短该文件首次读取的等待时间。
+
+启用 Transfer 后，可使用 `cv transfer list` 和 `cv transfer status <job_id>` 执行任务级运维；`cv load-status` 仍是兼容的状态查询命令。
 
 :::tip
 加载数据前，须先将 UFS 挂载到 Curvine（`cv mount`）。

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/3-User-Manuals/2-Operations/02-cli.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/3-User-Manuals/2-Operations/02-cli.md
@@ -1,6 +1,6 @@
 # 命令行工具
 
-本节基于当前仓库源码中的 `curvine-cli`、`build/bin/cv` 和 `build/bin/dfs` 整理 Curvine 的命令行入口。当前主要有三类：
+本节基于当前仓库源码中的 `curvine-cli`、`build/cv` 和 `build/bin/dfs` 整理 Curvine 的命令行入口。当前主要有三类：
 
 - **原生 Rust CLI `cv`**：推荐入口，功能最完整，命令树来自 `curvine-cli`。
 - **兼容包装器 `dfs`**：发行包自带的兼容入口，`fs` / `report` 走 Java `CurvineShell`，保留 Hadoop `FsShell` 风格。
@@ -25,8 +25,10 @@ Commands:
   fs
   report
   load
+  export
   load-status
   cancel-load
+  transfer
   mount
   umount
   node
@@ -37,16 +39,16 @@ Commands:
 
 | 全局参数 | 说明 |
 |----------|------|
-| `-c, --conf <PATH>` | 集群配置文件路径。未指定时会尝试使用环境变量 `CURVINE_CONF_FILE`。 |
+| `-c, --conf <PATH>` | 仅覆盖本次调用的集群配置文件。未指定时 CLI 使用正常配置路径或 `CURVINE_CONF_FILE`。 |
 | `--master-addrs <ADDRS>` | 直接覆盖客户端配置里的 Master 地址列表，例如 `m1:8995,m2:8995`。 |
 
 :::tip
-为避免歧义，本文统一使用 `--conf` 表示 CLI 配置文件，使用 `--config key=value` 表示 `mount` 的 UFS 参数。不要在 `mount` 场景里依赖短参数 `-c`。
+生产环境通常直接使用 `cv`，因为集群配置已安装，或已通过 `CURVINE_CONF_FILE` 选择。仅在迁移或诊断时使用 `--conf` 指向非默认配置。`cv mount --config key=value` 仍表示 UFS 配置项。
 :::
 
 **约定：**
 
-- 发行包里通常通过 `build/dist/bin/cv` 调用。
+- 生产环境将发行包的 `bin/` 加入 `PATH` 后，直接使用 `cv`。
 - 通过 `cargo run -p curvine-cli -- ...` 运行时，帮助中的程序名会显示为 `curvine-cli`。
 - 本文中的 `<PATH>`、`<JOB_ID>` 等为位置参数；`[OPTION]` 表示可选项。
 
@@ -68,13 +70,13 @@ Commands:
 示例：
 
 ```bash
-bin/cv report
-bin/cv report json
-bin/cv report all --show-workers false
-bin/cv report capacity
-bin/cv report capacity 192.168.1.10
-bin/cv report used
-bin/cv report available
+cv report
+cv report json
+cv report all --show-workers false
+cv report capacity
+cv report capacity 192.168.1.10
+cv report used
+cv report available
 ```
 
 :::note
@@ -101,10 +103,10 @@ bin/cv report available
 示例：
 
 ```bash
-bin/cv node -l
-bin/cv node --add-decommission host1:8997 host2:8997
-bin/cv node --add-decommission host1:8997,host2:8997
-bin/cv node --remove-decommission host1:8997
+cv node -l
+cv node --add-decommission host1:8997 host2:8997
+cv node --add-decommission host1:8997,host2:8997
+cv node --remove-decommission host1:8997
 ```
 
 :::note
@@ -147,21 +149,21 @@ bin/cv node --remove-decommission host1:8997
 常用示例：
 
 ```bash
-bin/cv fs ls /
-bin/cv fs ls / --cache-only
-bin/cv fs mkdir -p /data/a/b
-bin/cv fs put ./local.txt /data/remote.txt
-bin/cv fs get /data/remote.txt ./local.txt
-bin/cv fs cat /data/remote.txt
-bin/cv fs stat /data
-bin/cv fs count /data
-bin/cv fs mv /data/a /data/b
-bin/cv fs du -h /data
-bin/cv fs df -h
-bin/cv fs chmod 755 /data/script.sh
-bin/cv fs chown user:group /data
-bin/cv fs blocks /data/file.txt --format json
-bin/cv fs free /data --recursive
+cv fs ls /
+cv fs ls / --cache-only
+cv fs mkdir -p /data/a/b
+cv fs put ./local.txt /data/remote.txt
+cv fs get /data/remote.txt ./local.txt
+cv fs cat /data/remote.txt
+cv fs stat /data
+cv fs count /data
+cv fs mv /data/a /data/b
+cv fs du -h /data
+cv fs df -h
+cv fs chmod 755 /data/script.sh
+cv fs chown user:group /data
+cv fs blocks /data/file.txt --format json
+cv fs free /data --recursive
 ```
 
 `cv fs ls` 额外支持类 HDFS 的选项：
@@ -231,13 +233,13 @@ bin/cv fs free /data --recursive
 
 ```bash
 # 列出挂载点
-bin/cv mount
+cv mount
 
 # 列出挂载点并检查 UFS 可达性
-bin/cv mount --check
+cv mount --check
 
 # 创建 S3 挂载
-bin/cv mount s3://bucket/datasets /bucket/datasets \
+cv mount s3://bucket/datasets /bucket/datasets \
   --config s3.endpoint_url=http://hostname.com \
   --config s3.region_name=cn \
   --config s3.credentials.access=access_key \
@@ -246,13 +248,13 @@ bin/cv mount s3://bucket/datasets /bucket/datasets \
   --provider opendal
 
 # 通过 JindoSDK / OSS-HDFS 创建 OSS 挂载
-bin/cv mount oss://my-bucket/prefix /oss-data --provider oss-hdfs \
+cv mount oss://my-bucket/prefix /oss-data --provider oss-hdfs \
   --config oss.endpoint=oss-cn-hangzhou.aliyuncs.com \
   --config oss.accessKeyId=xxx \
   --config oss.accessKeySecret=yyy
 
 # 手动执行一次元数据 resync
-bin/cv mount resync /bucket/datasets --dry-run --verbose
+cv mount resync /bucket/datasets --dry-run --verbose
 ```
 
 各 UFS 类型（S3、OSS、HDFS、WebHDFS）的常见参数列表见文末 [附录：UFS 挂载参数](#附录ufs-挂载参数)。
@@ -274,7 +276,7 @@ bin/cv mount resync /bucket/datasets --dry-run --verbose
 示例：
 
 ```bash
-bin/cv umount /bucket/datasets
+cv umount /bucket/datasets
 ```
 
 ---
@@ -287,20 +289,51 @@ bin/cv umount /bucket/datasets
 |-------------|------|
 | `<PATH>` | 要加载的源路径。通常是已经建立挂载关系的 UFS 路径。 |
 | `-w, --watch` | 提交后立即持续观察任务状态。 |
-| `--conf <PATH>` | CLI 配置文件。 |
+| `--conf <PATH>` | 可选的单次配置覆盖；日常使用不需要。 |
 
 示例：
 
 ```bash
-bin/cv load s3://bucket/datasets/train/part-0001.parquet
-bin/cv load s3://bucket/datasets/train/part-0001.parquet --watch
+cv load s3://bucket/datasets/train/part-0001.parquet
+cv load s3://bucket/datasets/train/part-0001.parquet --watch
 ```
 
 成功时命令会输出 `job_id` 和 `target_path`，后续可交给 `load-status` 或 `cancel-load`。
 
+#### Transfer 路由
+
+启用独立 Transfer 后，命令行不变：
+
+| 集群配置 | `cv load` / `cv export` 路由 |
+| --- | --- |
+| `[transfer] enabled = false` | 为兼容已有集群，调用旧 Master Load API。 |
+| `[transfer] enabled = true` | CLI 直接调用 Transfer 服务 RPC。 |
+
+Master 不会将旧请求代理到 Transfer。切换时，必须保证 CLI 与集群使用相同的 `[transfer]` 配置；过期的 CLI 配置会被拒绝，避免产生第二个任务所有者。
+
 ---
 
-### 7. `load-status`：查询加载任务状态
+### 7. `export`：将 Curvine 路径导出到 UFS
+
+**用法：** `cv export [OPTIONS] <PATH>`
+
+`<PATH>` 必须是一个挂载路径下的 Curvine 路径。Curvine 会根据挂载自动推导 UFS 目标路径。
+
+| 选项 / 参数 | 说明 |
+|-------------|------|
+| `<PATH>` | 要导出的 Curvine 源路径。 |
+| `-w, --watch` | 提交后立即持续观察任务状态。 |
+| `--no-overwrite` | UFS 目标已存在时失败。 |
+
+示例：
+
+```bash
+cv export /bucket/datasets/train/part-0001.parquet --watch
+```
+
+---
+
+### 8. `load-status`：查询加载任务状态
 
 **用法：** `cv load-status [OPTIONS] <JOB_ID>`
 
@@ -309,13 +342,13 @@ bin/cv load s3://bucket/datasets/train/part-0001.parquet --watch
 | `<JOB_ID>` | 加载任务 ID。 |
 | `-v, --verbose` | 详细输出。 |
 | `-w, --watch <INTERVAL>` | 轮询间隔，默认 `5s`。支持 `1s`、`1m`、`1h` 等格式。 |
-| `--conf <PATH>` | CLI 配置文件。 |
+| `--conf <PATH>` | 可选的单次配置覆盖；日常使用不需要。 |
 
 示例：
 
 ```bash
-bin/cv load-status <job_id>
-bin/cv load-status <job_id> -w 1s
+cv load-status <job_id>
+cv load-status <job_id> -w 1s
 ```
 
 :::note
@@ -324,31 +357,56 @@ bin/cv load-status <job_id> -w 1s
 
 ---
 
-### 8. `cancel-load`：取消加载任务
+### 9. `cancel-load`：取消加载任务
 
 **用法：** `cv cancel-load [OPTIONS] <JOB_ID>`
 
 | 选项 / 参数 | 说明 |
 |-------------|------|
 | `<JOB_ID>` | 要取消的任务 ID。 |
-| `--conf <PATH>` | CLI 配置文件。 |
+| `--conf <PATH>` | 可选的单次配置覆盖；日常使用不需要。 |
 
 示例：
 
 ```bash
-bin/cv cancel-load <job_id>
+cv cancel-load <job_id>
 ```
 
 ---
 
-### 9. `version`：查看版本
+### 10. `transfer`：运维 Transfer 任务
+
+`cv transfer` 仅在 `[transfer] enabled = true` 时可用。它用于列举、查看、重试和分页查询 Transfer 任务；日常提交仍使用 `cv load` 或 `cv export`。
+
+| 命令 | 说明 |
+| --- | --- |
+| `cv transfer list` | 列出任务。可使用 `--kind load\|export`、`--state`、`--tenant`、`--submitter` 过滤。 |
+| `cv transfer status <JOB_ID>` | 查看单个任务。使用 `--verbose` 查看任务明细，或用 `--watch --interval 1s` 轮询。 |
+| `cv transfer tasks <JOB_ID>` | 查看单个任务的 task 分页。 |
+| `cv transfer cancel <JOB_ID>` | 取消一个 Transfer 任务。 |
+| `cv transfer retry <JOB_ID>` | 将失败、取消或部分成功任务重试为一个新任务。 |
+| `cv transfer tenants` | 按 tenant 汇总任务。 |
+
+示例：
+
+```bash
+cv transfer list --kind load --state running
+cv transfer status <job_id> --watch --interval 2s
+cv transfer retry <job_id>
+```
+
+`load-status` 与 `cancel-load` 仍保留为兼容命令。启用 Transfer 时它们调用 Transfer；关闭时调用旧 Master 实现。
+
+---
+
+### 11. `version`：查看版本
 
 **用法：** `cv version`
 
 示例：
 
 ```bash
-bin/cv version
+cv version
 ```
 
 当前实现会输出 `curvine-cli <version>`，并带上 commit / branch 信息。


### PR DESCRIPTION
# Summary

Document standalone Transfer deployment, configuration, CLI routing, and operations for Load and Export.

# Issue Describe / Design

Related to #1040.

Transfer remains disabled by default, preserving the legacy Master path. When enabled, normal `cv load` and `cv export` commands select Transfer directly. The documentation describes the required MySQL production store, Helm endpoint inference, cutover sequence, and compatible status and cancel commands.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `2-Deploy/.../03-conf.md` | Add Transfer configuration, defaults, startup, and cutover guidance. | Documents disabled legacy mode and enabled Transfer mode. |
| `2-Deploy/.../01-k8s-Deployment.md` | Add Helm deployment and parameter references. | No chart behavior change. |
| `3-User-Manuals/2-Operations/02-cli.md` | Document `cv export`, Transfer routing, and `cv transfer` operations. | Normal CLI syntax remains unchanged. |
| `3-User-Manuals/1-Key-Features/02-cache.md` | Explain automatic-cache routing through Transfer. | No runtime behavior change. |
| Chinese mirrors | Keep Chinese deployment, configuration, CLI, and cache guidance aligned. | None. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `git diff --check` | PASS | No whitespace errors. |
| `npm run build` | PASS | English and Chinese Docusaurus sites built successfully. Existing blog, anchor, and Browserslist warnings remain. |

# Dependencies

- Related PRs: CurvineIO/curvine#1411, CurvineIO/curvine#1412, CurvineIO/curvine-helm#52
- Related issues: #1040
- Blocks / blocked by: Production Helm rollout requires an official Curvine image release containing Transfer.