### PR TITLE
docs(transfer): document SQLite PVC deployment (#1040)

### DIFF
--- a/docs/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/01-k8s-Deployment.md
+++ b/docs/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/01-k8s-Deployment.md
@@ -50,7 +50,8 @@ helm upgrade --install curvine curvine/curvine \
 
 Use a Curvine image release that contains the Transfer binary. Do not use an
 older chart image tag just because the chart itself supports the values below.
-For production, MySQL must be reachable before the Transfer Pod starts:
+For high availability or more than one Transfer replica, MySQL must be reachable
+before the Transfer Pod starts:
 
 ```yaml title="transfer-values.yaml"
 transfer:
@@ -71,9 +72,15 @@ writes its Service FQDN to `[transfer].hostname`. Curvine infers the RPC
 endpoint from that hostname and `transfer.rpcPort`; do not configure
 `endpoints` in normal Helm deployments.
 
-An empty `transfer.storeUrl` is a single-Pod SQLite development default. It
-uses an `emptyDir`, so it survives only container restarts in the same Pod. Use
-MySQL for production, and MySQL is mandatory when `transfer.replicas > 1`.
+An empty `transfer.storeUrl` uses the single-Pod SQLite default. The chart
+creates a `ReadWriteOnce` PVC for its data directory without setting
+`storageClassName`, so Kubernetes uses the default StorageClass. The PVC
+persists across Pod replacement. MySQL is mandatory when
+`transfer.replicas > 1` and recommended for high availability.
+
+For SQLite, the Transfer Deployment uses `Recreate` so the old Pod detaches its
+`ReadWriteOnce` volume before a replacement starts. Helm retains the SQLite PVC
+on uninstall; delete it explicitly only when discarding Transfer metadata.
 
 The generated ConfigMap is used by Master, Worker, and Transfer. External CLI
 hosts must also use a cluster config with `[transfer] enabled = true`; the CLI
@@ -248,7 +255,8 @@ Set `openKruise.enabled=true` to install the kruise subchart and switch master/w
 | Parameter | Default | Description |
 |-----------|---------|-------------|
 | `transfer.enabled` | `false` | Creates no Transfer resources until enabled; disabled mode preserves the legacy Master Load API. |
-| `transfer.storeUrl` | `""` | Empty infers local SQLite. Use `mysql://...` for durable production storage. |
+| `transfer.storeUrl` | `""` | Empty infers local SQLite backed by a chart-managed PVC. Use `mysql://...` for high availability or multiple replicas. |
+| `transfer.storage.size` | `1Gi` | Requested capacity for the SQLite PVC. Kubernetes selects the default StorageClass. |
 | `transfer.replicas` | `1` | Transfer Pod replicas. Values greater than one require a MySQL `storeUrl`. |
 | `transfer.rpcPort` | `9010` | Transfer RPC Service and container port. |
 | `transfer.webPort` | `9011` | Transfer `/healthz`, `/readyz`, and `/metrics` port. |

--- a/docs/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/03-conf.md
+++ b/docs/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/03-conf.md
@@ -229,8 +229,9 @@ the cutover.
 
 ### Required production settings
 
-For a single local development process, `enabled = true` is enough: Curvine
-infers a local SQLite database. Production requires a reachable MySQL URL:
+For a single Transfer instance, `enabled = true` is enough: Curvine infers a
+local SQLite database. High availability and more than one Transfer replica
+require a reachable MySQL URL:
 
 ```toml
 [transfer]
@@ -253,7 +254,9 @@ bin/curvine-transfer.sh start
 
 Cut over in this order:
 
-1. Make MySQL reachable and add `[transfer]` to the shared cluster config.
+1. Prepare persistent Transfer storage: a durable SQLite path for one instance,
+   or MySQL for high availability and multiple instances. Add `[transfer]` to
+   the shared cluster config.
 2. Start Transfer and wait for its RPC and web endpoints to become ready.
 3. Restart Master and Worker so they read `transfer.enabled = true`.
 4. Distribute the same config to CLI hosts, then submit with normal `cv load`
@@ -271,7 +274,7 @@ duration syntax such as `90s`, `24h`, and `168h`.
 | Field | Default | Meaning |
 | --- | --- | --- |
 | `enabled` | `false` | Enables Transfer mode. `false` preserves the legacy Master Load / Export path. |
-| `store_url` | `sqlite://data/transfer/transfer.db` after inference | Job metadata store. Use `mysql://...` for durable production operation and for more than one Transfer replica. |
+| `store_url` | `sqlite://data/transfer/transfer.db` after inference | Job metadata store. Use a persistent SQLite path for one Transfer instance, or `mysql://...` for high availability and more than one replica. |
 | `hostname` | `localhost` | Advertised Transfer hostname. In Kubernetes the chart sets the internal Service DNS automatically. |
 | `rpc_port` | `9010` | Transfer RPC port. |
 | `web_port` | `9011` | Transfer web endpoint for `/healthz`, `/readyz`, and `/metrics`. |

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/01-k8s-Deployment.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/01-k8s-Deployment.md
@@ -48,7 +48,7 @@ helm upgrade --install curvine curvine/curvine \
 
 ### 启用 Transfer
 
-使用包含 Transfer 二进制的 Curvine 镜像版本；不要只因 Chart 支持以下参数就使用较旧的镜像 tag。生产环境必须先保证 MySQL 可达，再启动 Transfer Pod：
+使用包含 Transfer 二进制的 Curvine 镜像版本；不要只因 Chart 支持以下参数就使用较旧的镜像 tag。高可用或多副本部署时，必须先保证 MySQL 可达，再启动 Transfer Pod：
 
 ```yaml title="transfer-values.yaml"
 transfer:
@@ -66,7 +66,9 @@ helm upgrade --install curvine curvine/curvine \
 
 Chart 会创建仅集群内可见的 `curvine-transfer` `ClusterIP` Service，并将其 FQDN 写入 `[transfer].hostname`。Curvine 根据该 hostname 和 `transfer.rpcPort` 自动推导 RPC 地址；常规 Helm 部署不要配置 `endpoints`。
 
-`transfer.storeUrl` 为空时使用单 Pod SQLite 开发默认值，数据位于 `emptyDir`，只会跨同一 Pod 内的容器重启保留。生产环境使用 MySQL；`transfer.replicas > 1` 时 MySQL 是必需的。
+`transfer.storeUrl` 为空时使用单 Pod SQLite 默认值。Chart 会为其数据目录创建 `ReadWriteOnce` PVC，且不设置 `storageClassName`，因此 Kubernetes 自动使用默认 StorageClass；Pod 被替换后数据仍会保留。`transfer.replicas > 1` 时 MySQL 是必需的，高可用部署也建议使用 MySQL。
+
+SQLite 模式下，Transfer Deployment 使用 `Recreate`，使旧 Pod 在新 Pod 启动前释放 `ReadWriteOnce` 卷。Helm 卸载时会保留 SQLite PVC；只有明确丢弃 Transfer 元数据时才手动删除它。
 
 生成的 ConfigMap 同时供 Master、Worker 和 Transfer 使用。集群外 CLI 主机也必须使用 `[transfer] enabled = true` 的集群配置；客户端命令仍是 `cv load`、`cv export`、`cv load-status` 和 `cv cancel-load`。
 
@@ -173,7 +175,8 @@ Chart 版本 `0.3.2-alpha`。下表默认值与 `helm show values curvine/curvin
 | 参数 | 默认值 | 说明 |
 |-----------|---------|-------------|
 | `transfer.enabled` | `false` | 未启用时不创建 Transfer 资源；关闭时保持旧 Master Load API。 |
-| `transfer.storeUrl` | `""` | 空值自动推导本地 SQLite。生产持久化存储使用 `mysql://...`。 |
+| `transfer.storeUrl` | `""` | 空值自动推导由 Chart 管理 PVC 的本地 SQLite。高可用或多副本使用 `mysql://...`。 |
+| `transfer.storage.size` | `1Gi` | SQLite PVC 的申请容量；Kubernetes 自动选择默认 StorageClass。 |
 | `transfer.replicas` | `1` | Transfer Pod 副本数。大于 1 时必须使用 MySQL `storeUrl`。 |
 | `transfer.rpcPort` | `9010` | Transfer RPC Service 与容器端口。 |
 | `transfer.webPort` | `9011` | Transfer `/healthz`、`/readyz`、`/metrics` 端口。 |

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/03-conf.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/03-conf.md
@@ -222,7 +222,7 @@ Master 不会将旧 Load / Export 请求转发给 Transfer。切换到 Transfer 
 
 ### 生产环境必填配置
 
-单进程本地开发只需设置 `enabled = true`，Curvine 会推导本地 SQLite。生产环境需要一个可连接的 MySQL URL：
+单个 Transfer 实例只需设置 `enabled = true`，Curvine 会推导本地 SQLite。高可用或多副本 Transfer 需要一个可连接的 MySQL URL：
 
 ```toml
 [transfer]
@@ -242,7 +242,7 @@ bin/curvine-transfer.sh start
 
 按以下顺序切换：
 
-1. 确保 MySQL 可达，并在共享集群配置中加入 `[transfer]`。
+1. 准备持久化的 Transfer 存储：单实例使用持久 SQLite 路径，高可用或多实例使用 MySQL；然后在共享集群配置中加入 `[transfer]`。
 2. 启动 Transfer，等待其 RPC 与 Web 端点就绪。
 3. 重启 Master 和 Worker，使其读取 `transfer.enabled = true`。
 4. 向 CLI 主机分发同一份配置，然后仍通过普通 `cv load` 或 `cv export` 提交任务。
@@ -256,7 +256,7 @@ bin/curvine-transfer.sh start
 | 字段 | 默认值 | 含义 |
 | --- | --- | --- |
 | `enabled` | `false` | 启用 Transfer 模式。`false` 保留旧 Master Load / Export 路径。 |
-| `store_url` | 推导后为 `sqlite://data/transfer/transfer.db` | 任务元数据存储。生产环境和多副本 Transfer 使用 `mysql://...`。 |
+| `store_url` | 推导后为 `sqlite://data/transfer/transfer.db` | 任务元数据存储。单实例使用持久 SQLite 路径；高可用或多副本 Transfer 使用 `mysql://...`。 |
 | `hostname` | `localhost` | 对外声明的 Transfer 主机名。Kubernetes Chart 会自动设置为集群内 Service DNS。 |
 | `rpc_port` | `9010` | Transfer RPC 端口。 |
 | `web_port` | `9011` | 提供 `/healthz`、`/readyz`、`/metrics` 的 Web 端口。 |


### PR DESCRIPTION
# Summary

Document the chart-managed PVC used by the default single-replica SQLite Transfer store.

# Issue Describe / Design

Related to CurvineIO/curvine#1040 and CurvineIO/curvine-helm#52.

An empty `transfer.storeUrl` now uses a `ReadWriteOnce` PVC selected by the cluster default StorageClass. The documentation distinguishes this durable single-replica mode from MySQL, which is required for multiple Transfer replicas and recommended for high availability.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `2-Deploy/.../01-k8s-Deployment.md` | Document the default SQLite PVC, capacity, Recreate strategy, and retention on uninstall. | Corrects prior emptyDir guidance. |
| `2-Deploy/.../03-conf.md` | Clarify SQLite and MySQL deployment boundaries. | No runtime behavior change. |
| Chinese mirrors | Keep Kubernetes and configuration guidance aligned. | None. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `git diff --check` | PASS | No whitespace errors. |
| `npm run build` | PASS | English and Chinese Docusaurus sites built successfully. Existing blog, anchor, and Browserslist warnings remain. |

# Dependencies

- Related PRs: CurvineIO/curvine-helm#52
- Related issues: CurvineIO/curvine#1040
- Blocks / blocked by: None