### PR TITLE
docs(transfer): add deployment guide (CurvineIO/curvine#1040)

### DIFF
--- a/docs/2-Deploy/0-Deployment-Overview.md
+++ b/docs/2-Deploy/0-Deployment-Overview.md
@@ -1,0 +1,41 @@
+---
+sidebar_position: 0
+---
+
+# Deployment Overview
+
+This chapter separates cluster installation from optional services. Deploy and
+verify the Curvine Master and Workers first. Add the Transfer service only when
+Load or Export jobs should run outside the Master process.
+
+## Deployment Sequence
+
+1. Choose a cluster form.
+   - Use [Quick Start](./1-quick-start.md) for a local evaluation.
+   - Use [Standalone Mode](./2-Deploy-Curvine-Cluster/2-Standalone-Mode.md) for a
+     single-host cluster.
+   - Use [bare metal](./2-Deploy-Curvine-Cluster/3-Distributed-Mode/02-Bare-Metal-Deployment.md)
+     or [Kubernetes](./2-Deploy-Curvine-Cluster/3-Distributed-Mode/01-k8s-Deployment.md)
+     for a distributed cluster.
+2. Verify that Master and Worker processes are healthy and that required UFS
+   mounts can be listed with `cv mount --check`.
+3. If the cluster needs independent Load and Export scheduling, deploy the
+   [Transfer Service](./3-Transfer-Service/0-Overview.md).
+4. Enable Transfer only in the clients that should use it. Existing clients can
+   continue to use the legacy Master job path during a staged rollout.
+
+## Documentation Boundaries
+
+- Cluster deployment pages describe Master, Worker, storage, and networking.
+- Transfer pages describe the independent scheduler, its state store, and
+  client routing.
+- The [configuration reference](./2-Deploy-Curvine-Cluster/3-Distributed-Mode/03-conf.md)
+  is the single source for configuration defaults. Deployment pages show only
+  the settings required for each topology.
+
+## Production Changes
+
+Treat upgrades as a separate operation. Verify version compatibility and
+configuration changes in a non-production cluster before changing the running
+cluster. For Transfer, use a shared MySQL store before running more than one
+instance.

--- a/docs/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/01-k8s-Deployment.md
+++ b/docs/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/01-k8s-Deployment.md
@@ -27,6 +27,13 @@ Helm release `curvine` is deployed in namespace `curvine`:
 
 `openKruise.enabled` defaults to `false`. StatefulSets use `apps/v1`.
 
+## Transfer Service
+
+Transfer is an optional service for independent Load and Export scheduling. It
+is not created by the current Helm chart and does not require changing the
+running Master or Worker configuration. Deploy it separately after the cluster
+is healthy; see [Deploy Transfer on Kubernetes](../../3-Transfer-Service/2-Kubernetes.md).
+
 ## Deployment
 
 ### Add repository

--- a/docs/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/02-Bare-Metal-Deployment.md
+++ b/docs/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/02-Bare-Metal-Deployment.md
@@ -48,6 +48,11 @@ flowchart TB
 - **Cluster core (required):** Start `curvine-master` and `curvine-worker` on the intended hosts. The cluster is operational once Master and Workers are running; you can use the CLI (`cv`) or SDK without FUSE.
 - **FUSE (optional):** Start `curvine-fuse` only when you need a POSIX filesystem mount (e.g. for legacy tools or scripts). FUSE is not a core service—the cluster does not depend on it to start or run.
 
+When Load and Export jobs need independent scheduling, deploy Transfer as a
+separate optional service after the cluster is healthy. It does not join the
+Master Raft group and does not require a Master or Worker configuration change.
+See [Deploy Transfer on Bare Metal](../../3-Transfer-Service/1-Bare-Metal.md).
+
 :::info
 **FUSE is not part of cluster startup.** The Curvine cluster is formed by Master and Worker nodes. FUSE is one of several access methods (along with CLI, SDK, S3 gateway) and is only needed when applications require a local mount point.
 :::

--- a/docs/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/03-conf.md
+++ b/docs/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/03-conf.md
@@ -37,8 +37,8 @@ The current `ClusterConf` contains these main sections:
 | `[fuse]` | FUSE mount and cache settings |
 | `[log]` | Global client / FUSE log settings |
 | `[s3_gateway]` | S3-compatible gateway settings |
-| `[job]` | Legacy Master load-job lifecycle and concurrency settings |
-| `[transfer]` | Standalone Load / Export service configuration |
+| `[job]` | Load-job lifecycle and concurrency settings |
+| `[transfer]` | Independent Load and Export service, state store, and client routing |
 | `[cli]` | CLI log settings |
 
 :::warning
@@ -214,81 +214,6 @@ Important FUSE defaults from `FuseConf`:
 | `check_permission` | `true` | Enforce permission checks |
 | `list_limit` | `1000` | Directory listing limit |
 
-## `[transfer]`
-
-Transfer separates Load and Export orchestration from Master. It is disabled by
-default, so an existing cluster continues to use the legacy Master Load API
-unchanged. When enabled, `cv load`, `cv export`, `cv load-status`, and
-`cv cancel-load` keep the same syntax but call Transfer directly.
-
-There is no Master-side redirect. The Master rejects a legacy Load / Export
-submission after it has been switched to Transfer mode, because accepting both
-paths would create two independent job owners. Therefore Master, Worker,
-Transfer, and external CLI hosts must use the same `[transfer]` setting during
-the cutover.
-
-### Required production settings
-
-For a single Transfer instance, `enabled = true` is enough: Curvine infers a
-local SQLite database. High availability and more than one Transfer replica
-require a reachable MySQL URL:
-
-```toml
-[transfer]
-enabled = true
-store_url = "mysql://transfer_user:password@mysql.example:3306/curvine_transfer"
-```
-
-Do not place a production password in source control. Distribute the same
-runtime configuration through the deployment system already used for the
-cluster and for CLI hosts.
-
-### Start and cut over
-
-For a package or bare-metal deployment, install a Curvine version containing
-the Transfer binary on the service host, then use the normal cluster config:
-
-```bash
-bin/curvine-transfer.sh start
-```
-
-Cut over in this order:
-
-1. Prepare persistent Transfer storage: a durable SQLite path for one instance,
-   or MySQL for high availability and multiple instances. Add `[transfer]` to
-   the shared cluster config.
-2. Start Transfer and wait for its RPC and web endpoints to become ready.
-3. Restart Master and Worker so they read `transfer.enabled = true`.
-4. Distribute the same config to CLI hosts, then submit with normal `cv load`
-   or `cv export` commands.
-
-Pause new Load / Export submissions while steps 2-4 are in progress. A CLI
-that still has `enabled = false` after Master has switched reports a clear
-legacy-API-disabled error; it is not silently redirected.
-
-### Parameters
-
-Only the following fields are operator configuration. Time values use Curvine
-duration syntax such as `90s`, `24h`, and `168h`.
-
-| Field | Default | Meaning |
-| --- | --- | --- |
-| `enabled` | `false` | Enables Transfer mode. `false` preserves the legacy Master Load / Export path. |
-| `store_url` | `sqlite://data/transfer/transfer.db` after inference | Job metadata store. Use a persistent SQLite path for one Transfer instance, or `mysql://...` for high availability and more than one replica. |
-| `hostname` | `localhost` | Advertised Transfer hostname. In Kubernetes the chart sets the internal Service DNS automatically. |
-| `rpc_port` | `9010` | Transfer RPC port. |
-| `web_port` | `9011` | Transfer web endpoint for `/healthz`, `/readyz`, and `/metrics`. |
-| `endpoints` | `[]` | Client RPC endpoints. Empty automatically becomes `hostname:rpc_port`; normally leave it empty. |
-| `instance_id` | empty | Lease owner ID. Empty generates a unique ID on each Transfer process start. |
-| `cv_metadata_reader` | `auto` | Resolves to the metadata replica reader. A MySQL production store requires this effective value to be `replica`. |
-| `max_running_transfers` | `64` | Maximum transfers allowed to run concurrently. |
-| `lease_timeout` | `120s` | Lease duration used to recover work from a lost Transfer instance. |
-| `terminal_retention` | `168h` | Retention period for completed, failed, or canceled transfer records. |
-
-`store_type`, `sqlite_path`, and `mysql_url` are compatibility inputs from an
-earlier configuration shape. Use `store_url`; it determines the store type from
-the URI and needs no separate selector.
-
 ## `[log]`, `[cli]`, `[job]`, `[s3_gateway]`
 
 ### Global `[log]`
@@ -301,9 +226,9 @@ The top-level `[log]` section is the shared client/FUSE log config. In the sampl
 
 ### `[job]`
 
-`[job]` configures the legacy Master job implementation used while
-`transfer.enabled = false`. After the Transfer cutover, job ownership,
-recovery, and retention use `[transfer]` instead.
+`[job]` configures the legacy Master job implementation used by clients with
+`transfer.enabled = false`. Transfer jobs use `[transfer]` for ownership,
+recovery, and retention.
 
 Important job defaults from `JobConf`:
 
@@ -315,6 +240,32 @@ Important job defaults from `JobConf`:
 | `task_timeout` | `1h` |
 | `task_report_interval` | `10s` |
 | `worker_max_concurrent_tasks` | `100` |
+
+## `[transfer]`
+
+`[transfer]` is read by the independent Transfer service and by clients that
+should submit Load and Export work to it. A Transfer service needs the normal
+`[client]` Master addresses in addition to this section. During a staged
+rollout, keep this section disabled in the Master and Worker configuration and
+enable it only in the Transfer and selected client configurations.
+
+| Field | Default | Meaning |
+| --- | --- | --- |
+| `enabled` | `false` | Enable Transfer routing in this process. On a client, `load` and `export` use Transfer; on a Transfer server, it enables the service. |
+| `store_url` | `sqlite://data/transfer/transfer.db` | State store URL. Use `sqlite:///absolute/path.db` for one instance or one shared `mysql://...` URL for multiple instances. |
+| `hostname` | `localhost` | RPC and web bind hostname when explicit endpoints are not supplied. |
+| `rpc_port` | `9010` | Transfer RPC port. |
+| `web_port` | `9011` | Health and metrics HTTP port. |
+| `endpoints` | Derived as `["<hostname>:<rpc_port>"]` | Client-facing Transfer RPC addresses. Use a Service or load-balancer address rather than a bind address. |
+| `instance_id` | empty | Optional stable service owner ID. When empty, the Transfer process generates a UUID. |
+| `max_running_transfers` | `64` | Maximum jobs this Transfer instance executes concurrently. |
+| `lease_timeout` | `120s` | Ownership lease duration used for recovery and multi-instance coordination. |
+| `terminal_retention` | `168h` | Retention period for completed, failed, and canceled job records. |
+
+Do not use the deprecated compatibility inputs `store_type`, `sqlite_path`, or
+`mysql_url` in new configurations. `store_url` determines the storage backend
+from its URL scheme. Internal queue, probe, and scheduler values are not part
+of the supported user configuration surface.
 
 ### `[s3_gateway]`
 

--- a/docs/2-Deploy/3-Transfer-Service/0-Overview.md
+++ b/docs/2-Deploy/3-Transfer-Service/0-Overview.md
@@ -1,0 +1,93 @@
+---
+sidebar_position: 0
+---
+
+# Transfer Service
+
+Transfer is an independent service for Load and Export jobs. It persists job
+state, plans work from mount and Worker information, dispatches tasks to
+Workers, and receives task reports. It does not host a replica of the full
+Curvine metadata tree.
+
+Deploy Transfer after the Master and Workers are healthy. It is optional: a
+cluster that does not enable Transfer continues to use the legacy Master Load
+and Export path.
+
+```mermaid
+flowchart LR
+    C[CLI or SDK] -->|Load / Export| T[Transfer service]
+    T -->|mount and Worker snapshot| M[Master]
+    T -->|Transfer task| W[Worker]
+    W -->|progress and terminal report| T
+```
+
+## Configuration Boundary
+
+The service and the client use different Transfer settings. Do not change the
+running Master or Worker configuration merely to deploy Transfer.
+
+| Component | Required change | Notes |
+| --- | --- | --- |
+| Transfer service | Set `transfer.enabled = true`, a persistent `store_url`, and a reachable endpoint. | The service configuration must also contain the existing cluster's Master addresses. |
+| CLI or SDK client | Set `transfer.enabled = true` and `transfer.endpoints`. | `cv load`, `cv export`, and compatible status/cancel commands then use Transfer automatically. |
+| Master | None. Keep Transfer disabled during staged rollout. | Enabling it makes the Master reject the legacy Load and Export RPCs. |
+| Worker | None. | Workers need a version that supports Transfer tasks. Report endpoints are included in each task. |
+
+The client configuration contains no database URL. The store belongs only to
+the Transfer service.
+
+## Choose a State Store
+
+| Store | Topology | Use it when |
+| --- | --- | --- |
+| SQLite | One Transfer instance and one persistent local volume. | Evaluation, development, or a single-instance deployment. |
+| MySQL | Two or more Transfer instances sharing one database. | Production high availability and rolling service upgrades. |
+
+Never point multiple Transfer instances at independent SQLite files. They would
+hold different job state and cannot fail over correctly.
+
+## Required Configuration
+
+The Transfer server needs a complete cluster configuration, including
+`[client]` Master addresses. Add this section only to the Transfer server's
+configuration file:
+
+```toml
+[transfer]
+enabled = true
+store_url = "sqlite:///var/lib/curvine-transfer/transfer.db"
+hostname = "transfer-1.example.com"
+endpoints = ["transfer-1.example.com:9010"]
+```
+
+For a MySQL-backed service, replace `store_url` with a shared MySQL URL. Do not
+put credentials in a client configuration file or a ConfigMap.
+
+Clients need only the routing settings:
+
+```toml
+[transfer]
+enabled = true
+endpoints = ["transfer-1.example.com:9010"]
+```
+
+If `endpoints` is omitted, Curvine derives one endpoint from
+`hostname:rpc_port`. Explicit endpoints are recommended for Kubernetes and for
+any address that differs from the bind address.
+
+## Deploy and Verify
+
+- [Deploy on bare metal](./1-Bare-Metal.md)
+- [Deploy on Kubernetes](./2-Kubernetes.md)
+- [Transfer configuration reference](../2-Deploy-Curvine-Cluster/3-Distributed-Mode/03-conf.md#transfer)
+
+After deployment, run `cv transfer list` from a client configured for Transfer.
+Submit a small mounted UFS file with `cv load <path> --watch`, then verify that
+the job reaches `Completed` and the target can be read with `cv fs --cache-only get`.
+
+## Rollout and Rollback
+
+Enable Transfer in clients gradually. A client with `transfer.enabled = false`
+continues to use the legacy Master job API, so deploying the service alone does
+not change existing workloads. To roll back a client, disable Transfer in that
+client configuration; do not delete a Transfer store while jobs are active.

--- a/docs/2-Deploy/3-Transfer-Service/1-Bare-Metal.md
+++ b/docs/2-Deploy/3-Transfer-Service/1-Bare-Metal.md
@@ -1,0 +1,101 @@
+---
+sidebar_position: 1
+---
+
+# Deploy Transfer on Bare Metal
+
+This guide deploys one independent Transfer process next to an existing
+Curvine cluster. Master and Worker processes must already be running and must
+come from a version that supports Transfer tasks.
+
+## Prepare the Service Configuration
+
+Start with the cluster configuration that already contains the Master addresses
+and create a Transfer-specific copy. The `[transfer]` section below is the only
+new section required for a single-instance SQLite deployment.
+
+```toml
+# conf/curvine-transfer.toml
+[transfer]
+enabled = true
+store_url = "sqlite:///var/lib/curvine-transfer/transfer.db"
+hostname = "transfer-1.example.com"
+rpc_port = 9010
+web_port = 9011
+endpoints = ["transfer-1.example.com:9010"]
+```
+
+Create the store directory with the same operating-system user that runs the
+service. The SQLite database must live on persistent local or block storage.
+Do not put it on a shared filesystem or run a second Transfer process against
+it.
+
+```bash
+install -d -o curvine -g curvine /var/lib/curvine-transfer
+```
+
+## Start and Stop
+
+The distribution includes a Transfer launcher. It sources `curvine-env.sh`,
+writes `logs/transfer.out`, and manages `transfer.pid`.
+
+```bash
+export CURVINE_HOME=/opt/curvine
+export CURVINE_CONF_FILE=$CURVINE_HOME/conf/curvine-transfer.toml
+
+$CURVINE_HOME/bin/curvine-transfer.sh start
+$CURVINE_HOME/bin/curvine-transfer.sh stop
+```
+
+## Run Under systemd
+
+Use the bundled launcher so that the service receives the normal Curvine shell
+environment. Save the following as `/etc/systemd/system/curvine-transfer.service`.
+
+```ini
+[Unit]
+Description=Curvine Transfer Service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=forking
+User=curvine
+Group=curvine
+WorkingDirectory=/opt/curvine
+Environment=CURVINE_CONF_FILE=/opt/curvine/conf/curvine-transfer.toml
+PIDFile=/opt/curvine/transfer.pid
+ExecStart=/opt/curvine/bin/curvine-transfer.sh start
+ExecStop=/opt/curvine/bin/curvine-transfer.sh stop
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+systemctl daemon-reload
+systemctl enable --now curvine-transfer
+systemctl status curvine-transfer
+```
+
+## Verify
+
+```bash
+curl --fail http://transfer-1.example.com:9011/readyz
+curl --fail http://transfer-1.example.com:9011/healthz
+
+export CURVINE_CONF_FILE=/opt/curvine/conf/curvine-transfer.toml
+/opt/curvine/bin/cv transfer list
+```
+
+The client address must be reachable from every CLI user and from every Worker
+that may execute a Transfer task.
+
+## High Availability
+
+For multiple Transfer processes, replace the SQLite URL with one shared MySQL
+`store_url`. Give every process a unique reachable address and publish one
+stable client endpoint through a load balancer or DNS name. Do not use multiple
+independent SQLite databases as failover targets.

--- a/docs/2-Deploy/3-Transfer-Service/2-Kubernetes.md
+++ b/docs/2-Deploy/3-Transfer-Service/2-Kubernetes.md
@@ -1,0 +1,167 @@
+---
+sidebar_position: 2
+---
+
+# Deploy Transfer on Kubernetes
+
+Deploy Transfer separately from the Master and Worker workloads. The current
+Curvine Helm chart does not create this service, so use a dedicated manifest.
+The SQLite manifest below is intentionally a single replica with a dedicated
+RWO volume.
+
+## Prerequisites
+
+- An existing Curvine Master and Worker deployment in the namespace.
+- A ConfigMap containing the existing `curvine-cluster.toml` with the key name
+  shown below. Replace `curvine-cluster-config` if your deployment uses a
+  different name.
+- A default `StorageClass` that supports `ReadWriteOnce` volumes, or a
+  `storageClassName` added to the PVC.
+- An image version that matches the Master and Worker version.
+
+## SQLite Single-Replica Manifest
+
+Save this as `transfer-sqlite.yaml`. Replace the image and namespace to match
+your cluster.
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: curvine-transfer-overlay
+data:
+  transfer.toml: |
+    [transfer]
+    enabled = true
+    store_url = "sqlite:///opt/curvine/data/transfer/transfer.db"
+    hostname = "0.0.0.0"
+    rpc_port = 9010
+    web_port = 9011
+    endpoints = ["curvine-transfer.curvine.svc.cluster.local:9010"]
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: curvine-transfer-data
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: curvine-transfer
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: curvine-transfer
+  template:
+    metadata:
+      labels:
+        app: curvine-transfer
+    spec:
+      initContainers:
+        - name: prepare-config
+          image: ghcr.io/curvineio/curvine:<version>
+          command: ["/bin/sh", "-ec"]
+          args:
+            - |
+              cp /base/curvine-cluster.toml /work/curvine-cluster.toml
+              printf '\n' >> /work/curvine-cluster.toml
+              cat /overlay/transfer.toml >> /work/curvine-cluster.toml
+          volumeMounts:
+            - { name: base-config, mountPath: /base, readOnly: true }
+            - { name: transfer-overlay, mountPath: /overlay, readOnly: true }
+            - { name: config-work, mountPath: /work }
+      containers:
+        - name: transfer
+          image: ghcr.io/curvineio/curvine:<version>
+          command: ["/entrypoint.sh"]
+          args: ["transfer", "start"]
+          env:
+            - { name: CURVINE_HOME, value: /app/curvine }
+            - { name: CURVINE_CONF_FILE, value: /app/curvine/conf/curvine-cluster.toml }
+            - { name: ORPC_BIND_HOSTNAME, value: 0.0.0.0 }
+          ports:
+            - { name: rpc, containerPort: 9010 }
+            - { name: web, containerPort: 9011 }
+          startupProbe:
+            httpGet: { path: /readyz, port: web }
+            periodSeconds: 5
+            failureThreshold: 18
+          readinessProbe:
+            httpGet: { path: /readyz, port: web }
+            periodSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet: { path: /healthz, port: web }
+            periodSeconds: 10
+            failureThreshold: 3
+          resources:
+            requests: { cpu: "1", memory: 1Gi }
+            limits: { cpu: "2", memory: 2Gi }
+          volumeMounts:
+            - name: config-work
+              mountPath: /app/curvine/conf/curvine-cluster.toml
+              subPath: curvine-cluster.toml
+              readOnly: true
+            - { name: transfer-data, mountPath: /opt/curvine/data/transfer }
+      volumes:
+        - name: base-config
+          configMap: { name: curvine-cluster-config }
+        - name: transfer-overlay
+          configMap: { name: curvine-transfer-overlay }
+        - name: config-work
+          emptyDir: {}
+        - name: transfer-data
+          persistentVolumeClaim: { claimName: curvine-transfer-data }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: curvine-transfer
+spec:
+  selector:
+    app: curvine-transfer
+  ports:
+    - { name: rpc, port: 9010, targetPort: rpc }
+    - { name: web, port: 9011, targetPort: web }
+```
+
+Mount only the generated `curvine-cluster.toml` file into the main container.
+Mounting an `emptyDir` over the whole `/app/curvine/conf` directory hides the
+image's `curvine-env.sh` and breaks bundled client scripts.
+
+Apply and verify the service:
+
+```bash
+kubectl -n curvine apply -f transfer-sqlite.yaml
+kubectl -n curvine rollout status deployment/curvine-transfer
+kubectl -n curvine get pod,svc,pvc -l app=curvine-transfer
+kubectl -n curvine exec deployment/curvine-transfer -- curl --fail http://127.0.0.1:9011/readyz
+```
+
+## Configure Clients
+
+For clients inside the Kubernetes cluster, use the Service DNS name:
+
+```toml
+[transfer]
+enabled = true
+endpoints = ["curvine-transfer.curvine.svc.cluster.local:9010"]
+```
+
+For a client outside the cluster, publish an address that it can reach. A
+`.svc.cluster.local` address is only valid from the cluster network.
+
+## MySQL Multi-Replica Deployment
+
+To run more than one Transfer replica, use a shared MySQL `store_url` supplied
+through a Secret, remove the SQLite PVC, and expose all replicas through the
+same ClusterIP Service. All replicas must use the same database and compatible
+image version. Do not scale the SQLite Deployment above one replica.

--- a/docs/2-Deploy/3-Transfer-Service/_category_.json
+++ b/docs/2-Deploy/3-Transfer-Service/_category_.json
@@ -1,0 +1,7 @@
+{
+  "label": "Transfer Service",
+  "position": 3,
+  "link": {
+    "type": "generated-index"
+  }
+}

--- a/docs/3-User-Manuals/1-Key-Features/02-cache.md
+++ b/docs/3-User-Manuals/1-Key-Features/02-cache.md
@@ -206,23 +206,30 @@ Example log output:
 Submit async cache successfully for s3://bucket/cache/test.log, job res CacheJobResult { job_id: 7c00853f-13c8-43c1-8b3f-44740750b5a0, target_path: /s3/cache/test.log }
 ```
 
-Use the `job_id` to query the caching task status:
+When the client has Transfer enabled, automatic caching creates a Transfer job.
+Use the job ID to query its status:
 
 ```plain
-cv load-status 7c00853f-13c8-43c1-8b3f-44740750b5a0
+cv transfer status 7c00853f-13c8-43c1-8b3f-44740750b5a0
 ```
+
+`load-status` remains a compatibility command. A client without Transfer
+enabled continues to query the legacy Master job path.
 
 ### 9.2 Proactive Caching
 
-You can proactively load UFS data into Curvine using the `load` command:
+Mount the UFS first, then proactively load its Curvine path:
 
 ```plain
-cv load s3://bucket/cache/test.log
+cv load /data/cache/test.log --watch
 ```
 
 Automatic caching and proactive caching are not mutually exclusive. Proactive caching can reduce the time required for the first read of a UFS file.
 
-When Transfer is enabled, use `cv transfer list` and `cv transfer status <job_id>` for job-wide operations. `cv load-status` remains the compatible status command.
+With Transfer enabled in the client configuration, `cv load` automatically
+submits a Transfer job. Use `cv transfer list` and `cv transfer status <job_id>`
+for job-wide operations. Deployment and client routing are described in
+[Transfer Service](../../2-Deploy/3-Transfer-Service/0-Overview.md).
 
 :::tip
 Before loading data, the UFS must first be mounted to Curvine with `cv mount`.

--- a/docs/3-User-Manuals/2-Operations/02-cli.md
+++ b/docs/3-User-Manuals/2-Operations/02-cli.md
@@ -39,7 +39,7 @@ All `cv` commands accept these global options:
 
 | Global option | Description |
 |---------------|-------------|
-| `-c, --conf <PATH>` | Override the cluster config file for this invocation. If omitted, the CLI uses its normal configured path or `CURVINE_CONF_FILE`. |
+| `--conf <PATH>` | Override the cluster config file for this invocation. If omitted, the CLI uses its normal configured path or `CURVINE_CONF_FILE`. |
 | `--master-addrs <ADDRS>` | Override the client-side master address list directly, for example `m1:8995,m2:8995`. |
 
 :::tip
@@ -284,37 +284,41 @@ cv umount /bucket/datasets
 
 ---
 
-### 6. `load`: submit a load job
+### 6. `load`: submit a Load job
 
-**Usage:** `cv load [OPTIONS] <PATH>`
+**Usage:** `cv load [OPTIONS] <SOURCE_PATH> [TARGET_PATH]`
 
 | Option / Argument | Description |
 |-------------------|-------------|
-| `<PATH>` | Source path to load. In practice this is usually a UFS path that already belongs to a mount. |
+| `<SOURCE_PATH>` | UFS source URI or a Curvine path below an existing mount. |
+| `[TARGET_PATH]` | Optional Curvine destination. A mounted source path derives its target automatically. |
 | `-w, --watch` | Watch job status immediately after submission. |
-| `--conf <PATH>` | Optional one-command config override; normal use does not need it. |
+| `--no-overwrite` | Fail instead of replacing an existing target. |
 
 Examples:
 
 ```bash
-cv load s3://bucket/datasets/train/part-0001.parquet
-cv load s3://bucket/datasets/train/part-0001.parquet --watch
+cv load /datasets/train/part-0001.parquet --watch
+cv load s3://bucket/datasets/train/part-0001.parquet /datasets/train/part-0001.parquet --no-overwrite --watch
 ```
 
-On success, the command prints `job_id` and `target_path`, which can then be used with `load-status` or `cancel-load`.
+With Transfer enabled, `load` submits a Transfer job. Otherwise it uses the
+legacy Master job path. The command prints a job ID and target path in either
+mode.
 
 #### Transfer routing
 
 The command line does not change when standalone Transfer is enabled:
 
-| Cluster configuration | `cv load` / `cv export` route |
+| Client configuration | `cv load` / `cv export` route |
 | --- | --- |
 | `[transfer] enabled = false` | Legacy Master Load API, for backward compatibility. |
 | `[transfer] enabled = true` | Transfer service RPC, selected directly by the CLI. |
 
-The Master does not proxy legacy submissions to Transfer. During a cutover, make
-sure the CLI has the same `[transfer]` configuration as the cluster; a stale
-CLI config is rejected rather than creating a second job owner.
+The Transfer service and the client must both be configured for Transfer. Master
+and Worker configuration does not change for a client-side rollout. A client
+with `transfer.enabled = false` continues to submit through the legacy Master
+API.
 
 ---
 
@@ -385,6 +389,9 @@ cv cancel-load <job_id>
 `cv transfer` is available only when `[transfer] enabled = true`. It is the
 operations command for listing, inspecting, retrying, and paging Transfer jobs;
 normal submission remains `cv load` or `cv export`.
+
+It requires a reachable Transfer endpoint in the client configuration. See
+[Transfer Service](../../2-Deploy/3-Transfer-Service/0-Overview.md) for deployment.
 
 | Command | Description |
 | --- | --- |

--- a/docs/5-Architecture/02-opendal-integration.md
+++ b/docs/5-Architecture/02-opendal-integration.md
@@ -65,31 +65,25 @@ bin/cv mount hdfs://namenode:9000/data /mnt/hdfs
 
 ### Load Feature - Loading External Data
 
-The `load` feature allows directly loading data from external storage into Curvine, supporting single file or batch loading.
-
-#### Single File Load Examples
-
-```bash
-# Load single file from S3
-bin/cv load s3://flink/user/simple_test.txt \
-    -c s3.endpoint_url=http://s3v2.dg-access-test.wanyol.com \
-    -c s3.region_name=cn-south-1 \
-    -c s3.credentials.access=*** \
-    -c s3.credentials.secret=***
-```
-
-#### Batch Load Examples
+Mount an external path once, including its UFS credentials and endpoint, then
+load through the mounted Curvine path. This keeps credentials out of every
+Load invocation and makes the source-to-target mapping unambiguous.
 
 ```bash
-# Load entire directory from OSS
-bin/cv load oss://my-bucket/datasets/ \
-    -c oss.endpoint_url=https://oss-cn-hangzhou.aliyuncs.com \
-    -c oss.credentials.access_key_id=*** \
-    -c oss.credentials.access_key_secret=***
+# The S3 path is already mounted at /mnt/s3.
+cv load /mnt/s3/simple_test.txt --watch
 
-# Load from HDFS
-bin/cv load hdfs://namenode:9000/data/logs/
+# Load a mounted OSS directory.
+cv load /mnt/oss/datasets --watch
+
+# Load a mounted HDFS directory.
+cv load /mnt/hdfs/logs --watch
 ```
+
+When Transfer is enabled in the client configuration, the same `cv load`
+command submits an independent Transfer job. See
+[Transfer Service deployment](../2-Deploy/3-Transfer-Service/0-Overview.md)
+for service and client configuration.
 
 ### Configuration Parameters
 
@@ -153,5 +147,4 @@ export LD_LIBRARY_PATH=/opt/hadoop/lib/native:$LD_LIBRARY_PATH
 ```
 
 **Note**: Ensure all Worker nodes have the correct Java and Hadoop environment variables configured, otherwise HDFS mount and load operations will fail.
-
 

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/2-Deploy/0-Deployment-Overview.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/2-Deploy/0-Deployment-Overview.md
@@ -1,0 +1,32 @@
+---
+sidebar_position: 0
+---
+
+# 部署总览
+
+本章区分集群安装与可选服务。先部署并验证 Curvine Master 和 Worker；只有在希望
+Load 或 Export 任务脱离 Master 进程运行时，才部署 Transfer 服务。
+
+## 部署顺序
+
+1. 选择集群形态。
+   - 本地体验使用[快速开始](./1-quick-start.md)。
+   - 单机集群使用[单机模式](./2-Deploy-Curvine-Cluster/2-Standalone-Mode.md)。
+   - 分布式集群使用[物理机](./2-Deploy-Curvine-Cluster/3-Distributed-Mode/02-Bare-Metal-Deployment.md)
+     或 [Kubernetes](./2-Deploy-Curvine-Cluster/3-Distributed-Mode/01-k8s-Deployment.md)。
+2. 确认 Master 和 Worker 健康，并使用 `cv mount --check` 验证必需的 UFS 挂载。
+3. 如需独立调度 Load 和 Export，部署 [Transfer 服务](./3-Transfer-Service/0-Overview.md)。
+4. 逐步在需要切换的客户端启用 Transfer。未启用的客户端在灰度期间仍可使用旧的
+   Master Job 路径。
+
+## 文档边界
+
+- 集群部署页面说明 Master、Worker、存储和网络。
+- Transfer 页面说明独立调度器、状态存储和客户端路由。
+- [配置参考](./2-Deploy-Curvine-Cluster/3-Distributed-Mode/03-conf.md)
+  是默认值的唯一来源；部署页面只展示对应拓扑的必填项。
+
+## 生产变更
+
+升级应作为独立操作执行。修改线上集群前，先在非生产环境验证版本兼容性和配置变更。
+如果需要运行多个 Transfer 实例，必须使用共享的 MySQL Store。

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/01-k8s-Deployment.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/01-k8s-Deployment.md
@@ -27,6 +27,12 @@ Helm release `curvine` 部署于 namespace `curvine`：
 
 默认 `openKruise.enabled=false`，StatefulSet 使用 `apps/v1`。
 
+## Transfer 服务
+
+Transfer 是用于独立调度 Load 和 Export 的可选服务。当前 Helm Chart 不会创建该服务，
+并且部署它不需要修改正在运行的 Master 或 Worker 配置。应在集群健康后单独部署，参见
+[Kubernetes 部署 Transfer](../../3-Transfer-Service/2-Kubernetes.md)。
+
 ## 部署
 
 ### 添加仓库

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/02-Bare-Metal-Deployment.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/02-Bare-Metal-Deployment.md
@@ -48,6 +48,10 @@ flowchart TB
 - **集群核心（必选）：** 在规划的主机上启动 `curvine-master` 与 `curvine-worker`。二者就绪后集群即可工作，可通过 CLI（`cv`）或 SDK 访问，**无需先启动 FUSE**。
 - **FUSE（可选）：** 仅当需要 POSIX 文件系统挂载（如兼容旧工具、脚本）时再启动 `curvine-fuse`。FUSE 不是核心服务，集群的启动与运行不依赖它。
 
+如需让 Load 和 Export 使用独立调度，应在集群健康后部署独立的可选 Transfer 服务。
+它不加入 Master Raft 组，也不要求修改 Master 或 Worker 配置。参见
+[物理机部署 Transfer](../../3-Transfer-Service/1-Bare-Metal.md)。
+
 :::info
 **FUSE 不参与集群启动。** Curvine 集群由 Master 与 Worker 组成。FUSE 与 CLI、SDK、S3 网关一样，只是多种访问方式之一，仅在应用需要本地挂载点时才有必要启用。
 :::

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/03-conf.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/2-Deploy/2-Deploy-Curvine-Cluster/3-Distributed-Mode/03-conf.md
@@ -37,8 +37,8 @@ Curvine 常见的配置输入包括：
 | `[fuse]` | FUSE 挂载与缓存参数 |
 | `[log]` | 全局 client / fuse 日志 |
 | `[s3_gateway]` | S3 兼容网关配置 |
-| `[job]` | 旧 Master load 任务的生命周期与并发控制 |
-| `[transfer]` | 独立的 Load / Export 服务配置 |
+| `[job]` | load 任务生命周期与并发控制 |
+| `[transfer]` | 独立 Load / Export 服务、状态存储和客户端路由 |
 | `[cli]` | CLI 日志配置 |
 
 :::warning
@@ -214,61 +214,6 @@ data_dir = [
 | `check_permission` | `true` | 是否执行权限检查 |
 | `list_limit` | `1000` | 目录列举数量限制 |
 
-## `[transfer]`
-
-Transfer 将 Load 和 Export 的编排从 Master 中独立出来。默认关闭，因此已有集群继续使用旧 Master Load API，不改变原有行为。开启后，`cv load`、`cv export`、`cv load-status` 和 `cv cancel-load` 命令不变，但会由 CLI 直接调用 Transfer。
-
-Master 不会将旧 Load / Export 请求转发给 Transfer。切换到 Transfer 模式后，Master 会拒绝旧请求，因为同时接受两条路径会产生两个独立的任务所有者。因此切换时，Master、Worker、Transfer 和集群外的 CLI 都必须使用相同的 `[transfer]` 配置。
-
-### 生产环境必填配置
-
-单个 Transfer 实例只需设置 `enabled = true`，Curvine 会推导本地 SQLite。高可用或多副本 Transfer 需要一个可连接的 MySQL URL：
-
-```toml
-[transfer]
-enabled = true
-store_url = "mysql://transfer_user:password@mysql.example:3306/curvine_transfer"
-```
-
-不要将生产密码写入源码。通过现有的部署系统向集群和 CLI 主机分发同一份运行时配置。
-
-### 启动与切换
-
-包部署或裸机部署时，在服务主机安装包含 Transfer 二进制的 Curvine 版本，然后使用集群的正常配置启动：
-
-```bash
-bin/curvine-transfer.sh start
-```
-
-按以下顺序切换：
-
-1. 准备持久化的 Transfer 存储：单实例使用持久 SQLite 路径，高可用或多实例使用 MySQL；然后在共享集群配置中加入 `[transfer]`。
-2. 启动 Transfer，等待其 RPC 与 Web 端点就绪。
-3. 重启 Master 和 Worker，使其读取 `transfer.enabled = true`。
-4. 向 CLI 主机分发同一份配置，然后仍通过普通 `cv load` 或 `cv export` 提交任务。
-
-执行步骤 2 至 4 时暂停新的 Load / Export 提交。若 Master 已切换而 CLI 仍使用 `enabled = false`，会收到清晰的旧 API 已禁用错误，不会被静默转发。
-
-### 参数
-
-以下是运维需要配置的字段。时长使用 Curvine 格式，例如 `90s`、`24h` 和 `168h`。
-
-| 字段 | 默认值 | 含义 |
-| --- | --- | --- |
-| `enabled` | `false` | 启用 Transfer 模式。`false` 保留旧 Master Load / Export 路径。 |
-| `store_url` | 推导后为 `sqlite://data/transfer/transfer.db` | 任务元数据存储。单实例使用持久 SQLite 路径；高可用或多副本 Transfer 使用 `mysql://...`。 |
-| `hostname` | `localhost` | 对外声明的 Transfer 主机名。Kubernetes Chart 会自动设置为集群内 Service DNS。 |
-| `rpc_port` | `9010` | Transfer RPC 端口。 |
-| `web_port` | `9011` | 提供 `/healthz`、`/readyz`、`/metrics` 的 Web 端口。 |
-| `endpoints` | `[]` | 客户端 RPC 地址。为空时自动推导为 `hostname:rpc_port`，通常保持为空。 |
-| `instance_id` | 空 | 租约所有者 ID。为空时每个 Transfer 进程启动自动生成唯一 ID。 |
-| `cv_metadata_reader` | `auto` | 实际使用元数据副本读取器。MySQL 生产存储要求其生效值为 `replica`。 |
-| `max_running_transfers` | `64` | 同时运行的 Transfer 最大数量。 |
-| `lease_timeout` | `120s` | 用于从失联 Transfer 实例恢复任务的租约时长。 |
-| `terminal_retention` | `168h` | 已完成、失败或取消任务记录的保留时间。 |
-
-`store_type`、`sqlite_path` 和 `mysql_url` 是早期配置形态的兼容输入。新配置只使用 `store_url`，存储类型由 URI 自动推导，不需要单独指定。
-
 ## `[log]`、`[cli]`、`[job]`、`[s3_gateway]`
 
 ### 全局 `[log]`
@@ -281,7 +226,7 @@ bin/curvine-transfer.sh start
 
 ### `[job]`
 
-`[job]` 用于 `transfer.enabled = false` 时的旧 Master 任务实现。切换到 Transfer 后，任务所有权、恢复和保留策略由 `[transfer]` 控制。
+`[job]` 用于 `transfer.enabled = false` 的客户端所走的旧 Master 任务实现。Transfer Job 的任务所有权、恢复和保留策略由 `[transfer]` 控制。
 
 `JobConf` 中关键默认值：
 
@@ -293,6 +238,28 @@ bin/curvine-transfer.sh start
 | `task_timeout` | `1h` |
 | `task_report_interval` | `10s` |
 | `worker_max_concurrent_tasks` | `100` |
+
+## `[transfer]`
+
+`[transfer]` 由独立 Transfer 服务和需要将 Load / Export 提交给该服务的客户端读取。
+Transfer 服务除本段外，还需要正常的 `[client]` Master 地址。灰度阶段应保持 Master 和
+Worker 配置中的 Transfer 为关闭状态，只在 Transfer 服务和选定客户端配置中启用。
+
+| 字段 | 默认值 | 含义 |
+| --- | --- | --- |
+| `enabled` | `false` | 在当前进程启用 Transfer 路由。客户端启用后 `load`、`export` 使用 Transfer；Transfer 服务端启用后启动该服务。 |
+| `store_url` | `sqlite://data/transfer/transfer.db` | 状态存储 URL。单实例使用 `sqlite:///绝对路径.db`；多实例使用一个共享 `mysql://...` URL。 |
+| `hostname` | `localhost` | 未显式配置 endpoint 时使用的 RPC / Web 监听 hostname。 |
+| `rpc_port` | `9010` | Transfer RPC 端口。 |
+| `web_port` | `9011` | 健康检查和指标 HTTP 端口。 |
+| `endpoints` | 推导为 `["<hostname>:<rpc_port>"]` | 客户端访问的 Transfer RPC 地址。应填写 Service 或负载均衡地址，而不是监听地址。 |
+| `instance_id` | 空 | 可选的稳定服务 owner ID。留空时 Transfer 进程自动生成 UUID。 |
+| `max_running_transfers` | `64` | 当前 Transfer 实例可并发执行的最大 Job 数。 |
+| `lease_timeout` | `120s` | 恢复和多实例协调使用的 owner 租约时长。 |
+| `terminal_retention` | `168h` | Completed、Failed、Canceled Job 记录的保留时间。 |
+
+新配置不要使用兼容字段 `store_type`、`sqlite_path`、`mysql_url`。`store_url` 根据 URL
+scheme 推导存储后端。内部队列、探测和调度参数不属于公开的用户配置面。
 
 ### `[s3_gateway]`
 

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/2-Deploy/3-Transfer-Service/0-Overview.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/2-Deploy/3-Transfer-Service/0-Overview.md
@@ -1,0 +1,87 @@
+---
+sidebar_position: 0
+---
+
+# Transfer 服务
+
+Transfer 是用于 Load 和 Export 任务的独立服务。它持久化任务状态，基于 mount 和
+Worker 信息规划任务，向 Worker 下发任务并接收回报。它不会保存完整 Curvine 元数据树
+的副本。
+
+应在 Master 和 Worker 健康后再部署 Transfer。它是可选服务：未启用 Transfer 的集群
+继续使用原有的 Master Load 和 Export 路径。
+
+```mermaid
+flowchart LR
+    C[CLI 或 SDK] -->|Load / Export| T[Transfer 服务]
+    T -->|mount 和 Worker 快照| M[Master]
+    T -->|Transfer task| W[Worker]
+    W -->|进度和最终回报| T
+```
+
+## 配置边界
+
+服务端与客户端使用不同的 Transfer 配置。部署 Transfer 时，不要修改正在运行的 Master
+或 Worker 配置。
+
+| 组件 | 必需变更 | 说明 |
+| --- | --- | --- |
+| Transfer 服务 | 配置 `transfer.enabled = true`、持久化 `store_url` 和可访问 endpoint。 | 服务配置还必须包含现有集群的 Master 地址。 |
+| CLI 或 SDK 客户端 | 配置 `transfer.enabled = true` 和 `transfer.endpoints`。 | `cv load`、`cv export` 及兼容的查询/取消命令会自动使用 Transfer。 |
+| Master | 无。灰度期间保持 Transfer 未启用。 | 启用后 Master 会拒绝旧 Load 和 Export RPC。 |
+| Worker | 无。 | Worker 只需使用支持 Transfer task 的版本；回报 endpoint 随任务下发。 |
+
+客户端配置中不需要数据库 URL。状态存储只属于 Transfer 服务端。
+
+## 选择状态存储
+
+| Store | 拓扑 | 适用场景 |
+| --- | --- | --- |
+| SQLite | 一个 Transfer 实例和一个持久化本地卷。 | 评估、开发或单实例部署。 |
+| MySQL | 两个及以上 Transfer 实例共享同一个数据库。 | 生产高可用和滚动升级。 |
+
+不要让多个 Transfer 实例使用彼此独立的 SQLite 文件。它们会持有不同的 Job 状态，无法
+正确故障切换。
+
+## 必填配置
+
+Transfer 服务端需要一份完整的集群配置，其中包括 `[client]` 的 Master 地址。只在
+Transfer 服务端配置中增加以下段落：
+
+```toml
+[transfer]
+enabled = true
+store_url = "sqlite:///var/lib/curvine-transfer/transfer.db"
+hostname = "transfer-1.example.com"
+endpoints = ["transfer-1.example.com:9010"]
+```
+
+使用 MySQL 时，将 `store_url` 改为共享的 MySQL URL。不要在客户端配置或 ConfigMap
+中写入数据库凭据。
+
+客户端只需要路由配置：
+
+```toml
+[transfer]
+enabled = true
+endpoints = ["transfer-1.example.com:9010"]
+```
+
+未配置 `endpoints` 时，Curvine 使用 `hostname:rpc_port` 推导一个地址。Kubernetes
+或监听地址与访问地址不同的场景应显式配置 endpoint。
+
+## 部署与验证
+
+- [物理机部署](./1-Bare-Metal.md)
+- [Kubernetes 部署](./2-Kubernetes.md)
+- [Transfer 配置参考](../2-Deploy-Curvine-Cluster/3-Distributed-Mode/03-conf.md#transfer)
+
+部署后，在已启用 Transfer 的客户端执行 `cv transfer list`。再对一个小型已挂载 UFS
+文件执行 `cv load <path> --watch`，确认任务进入 `Completed`，并使用
+`cv fs --cache-only get` 读取目标。
+
+## 灰度与回滚
+
+按客户端逐步启用 Transfer。`transfer.enabled = false` 的客户端继续调用旧 Master Job
+API，因此单独部署 Transfer 不会改变已有工作负载。回滚客户端时只需关闭该客户端的
+Transfer；存在运行中任务时，不要删除 Transfer Store。

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/2-Deploy/3-Transfer-Service/1-Bare-Metal.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/2-Deploy/3-Transfer-Service/1-Bare-Metal.md
@@ -1,0 +1,95 @@
+---
+sidebar_position: 1
+---
+
+# 物理机部署 Transfer
+
+本指南在现有 Curvine 集群旁部署一个独立的 Transfer 进程。Master 和 Worker 必须已经
+运行，并且使用支持 Transfer task 的版本。
+
+## 准备服务配置
+
+以已包含 Master 地址的集群配置为基础，创建一份仅供 Transfer 使用的副本。下面的
+`[transfer]` 是单实例 SQLite 部署唯一需要新增的配置段。
+
+```toml
+# conf/curvine-transfer.toml
+[transfer]
+enabled = true
+store_url = "sqlite:///var/lib/curvine-transfer/transfer.db"
+hostname = "transfer-1.example.com"
+rpc_port = 9010
+web_port = 9011
+endpoints = ["transfer-1.example.com:9010"]
+```
+
+使用运行服务的同一个操作系统用户创建 Store 目录。SQLite 数据库必须位于持久化本地盘
+或块存储上；不要放在共享文件系统上，也不要再启动第二个进程访问该数据库。
+
+```bash
+install -d -o curvine -g curvine /var/lib/curvine-transfer
+```
+
+## 启动与停止
+
+发行包包含 Transfer 启动脚本。它会加载 `curvine-env.sh`，写入
+`logs/transfer.out`，并维护 `transfer.pid`。
+
+```bash
+export CURVINE_HOME=/opt/curvine
+export CURVINE_CONF_FILE=$CURVINE_HOME/conf/curvine-transfer.toml
+
+$CURVINE_HOME/bin/curvine-transfer.sh start
+$CURVINE_HOME/bin/curvine-transfer.sh stop
+```
+
+## 使用 systemd 运行
+
+使用发行包内置脚本，以便服务拥有正常的 Curvine shell 环境。将下列内容保存为
+`/etc/systemd/system/curvine-transfer.service`。
+
+```ini
+[Unit]
+Description=Curvine Transfer Service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=forking
+User=curvine
+Group=curvine
+WorkingDirectory=/opt/curvine
+Environment=CURVINE_CONF_FILE=/opt/curvine/conf/curvine-transfer.toml
+PIDFile=/opt/curvine/transfer.pid
+ExecStart=/opt/curvine/bin/curvine-transfer.sh start
+ExecStop=/opt/curvine/bin/curvine-transfer.sh stop
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+systemctl daemon-reload
+systemctl enable --now curvine-transfer
+systemctl status curvine-transfer
+```
+
+## 验证
+
+```bash
+curl --fail http://transfer-1.example.com:9011/readyz
+curl --fail http://transfer-1.example.com:9011/healthz
+
+export CURVINE_CONF_FILE=/opt/curvine/conf/curvine-transfer.toml
+/opt/curvine/bin/cv transfer list
+```
+
+客户端地址必须可被所有 CLI 使用者和可能执行 Transfer task 的 Worker 访问。
+
+## 高可用
+
+运行多个 Transfer 进程时，将 SQLite URL 改为一个共享的 MySQL `store_url`。每个进程
+必须具有唯一且可访问的地址，并通过负载均衡或 DNS 向客户端提供一个稳定地址。不要将
+多个彼此独立的 SQLite 数据库作为故障切换目标。

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/2-Deploy/3-Transfer-Service/2-Kubernetes.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/2-Deploy/3-Transfer-Service/2-Kubernetes.md
@@ -1,0 +1,160 @@
+---
+sidebar_position: 2
+---
+
+# Kubernetes 部署 Transfer
+
+Transfer 与 Master、Worker 独立部署。当前 Curvine Helm Chart 不会创建该服务，因此应
+使用单独的清单。下方 SQLite 清单固定为单副本，并使用专用 RWO 卷。
+
+## 前置条件
+
+- 命名空间中已部署 Curvine Master 和 Worker。
+- 存在包含 `curvine-cluster.toml` 键的集群配置 ConfigMap。示例使用
+  `curvine-cluster-config`，请替换为实际名称。
+- 集群存在支持 `ReadWriteOnce` 的默认 `StorageClass`，或者在 PVC 上配置
+  `storageClassName`。
+- 镜像版本与 Master、Worker 一致。
+
+## SQLite 单副本清单
+
+将下列内容保存为 `transfer-sqlite.yaml`，并替换镜像和命名空间。
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: curvine-transfer-overlay
+data:
+  transfer.toml: |
+    [transfer]
+    enabled = true
+    store_url = "sqlite:///opt/curvine/data/transfer/transfer.db"
+    hostname = "0.0.0.0"
+    rpc_port = 9010
+    web_port = 9011
+    endpoints = ["curvine-transfer.curvine.svc.cluster.local:9010"]
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: curvine-transfer-data
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: curvine-transfer
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: curvine-transfer
+  template:
+    metadata:
+      labels:
+        app: curvine-transfer
+    spec:
+      initContainers:
+        - name: prepare-config
+          image: ghcr.io/curvineio/curvine:<version>
+          command: ["/bin/sh", "-ec"]
+          args:
+            - |
+              cp /base/curvine-cluster.toml /work/curvine-cluster.toml
+              printf '\n' >> /work/curvine-cluster.toml
+              cat /overlay/transfer.toml >> /work/curvine-cluster.toml
+          volumeMounts:
+            - { name: base-config, mountPath: /base, readOnly: true }
+            - { name: transfer-overlay, mountPath: /overlay, readOnly: true }
+            - { name: config-work, mountPath: /work }
+      containers:
+        - name: transfer
+          image: ghcr.io/curvineio/curvine:<version>
+          command: ["/entrypoint.sh"]
+          args: ["transfer", "start"]
+          env:
+            - { name: CURVINE_HOME, value: /app/curvine }
+            - { name: CURVINE_CONF_FILE, value: /app/curvine/conf/curvine-cluster.toml }
+            - { name: ORPC_BIND_HOSTNAME, value: 0.0.0.0 }
+          ports:
+            - { name: rpc, containerPort: 9010 }
+            - { name: web, containerPort: 9011 }
+          startupProbe:
+            httpGet: { path: /readyz, port: web }
+            periodSeconds: 5
+            failureThreshold: 18
+          readinessProbe:
+            httpGet: { path: /readyz, port: web }
+            periodSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet: { path: /healthz, port: web }
+            periodSeconds: 10
+            failureThreshold: 3
+          resources:
+            requests: { cpu: "1", memory: 1Gi }
+            limits: { cpu: "2", memory: 2Gi }
+          volumeMounts:
+            - name: config-work
+              mountPath: /app/curvine/conf/curvine-cluster.toml
+              subPath: curvine-cluster.toml
+              readOnly: true
+            - { name: transfer-data, mountPath: /opt/curvine/data/transfer }
+      volumes:
+        - name: base-config
+          configMap: { name: curvine-cluster-config }
+        - name: transfer-overlay
+          configMap: { name: curvine-transfer-overlay }
+        - name: config-work
+          emptyDir: {}
+        - name: transfer-data
+          persistentVolumeClaim: { claimName: curvine-transfer-data }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: curvine-transfer
+spec:
+  selector:
+    app: curvine-transfer
+  ports:
+    - { name: rpc, port: 9010, targetPort: rpc }
+    - { name: web, port: 9011, targetPort: web }
+```
+
+主容器只能挂载生成后的 `curvine-cluster.toml` 文件。若用 `emptyDir` 覆盖整个
+`/app/curvine/conf`，会遮蔽镜像中的 `curvine-env.sh`，导致发行包内置客户端脚本异常。
+
+应用并验证服务：
+
+```bash
+kubectl -n curvine apply -f transfer-sqlite.yaml
+kubectl -n curvine rollout status deployment/curvine-transfer
+kubectl -n curvine get pod,svc,pvc -l app=curvine-transfer
+kubectl -n curvine exec deployment/curvine-transfer -- curl --fail http://127.0.0.1:9011/readyz
+```
+
+## 配置客户端
+
+集群内客户端使用 Service DNS：
+
+```toml
+[transfer]
+enabled = true
+endpoints = ["curvine-transfer.curvine.svc.cluster.local:9010"]
+```
+
+集群外客户端必须使用自身可访问的地址；`.svc.cluster.local` 仅在集群网络内可用。
+
+## MySQL 多副本部署
+
+如需运行多个 Transfer 副本，应通过 Secret 提供共享 MySQL `store_url`，移除 SQLite
+PVC，并让所有副本使用同一个 ClusterIP Service。所有副本必须使用同一数据库和兼容的
+镜像版本。不要将 SQLite Deployment 扩容到一个以上副本。

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/2-Deploy/3-Transfer-Service/_category_.json
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/2-Deploy/3-Transfer-Service/_category_.json
@@ -1,0 +1,7 @@
+{
+  "label": "Transfer 服务",
+  "position": 3,
+  "link": {
+    "type": "generated-index"
+  }
+}

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/3-User-Manuals/1-Key-Features/02-cache.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/3-User-Manuals/1-Key-Features/02-cache.md
@@ -206,23 +206,27 @@ quota_eviction_high_rate = 0.8
 Submit async cache successfully for s3://bucket/cache/test.log, job res CacheJobResult { job_id: 7c00853f-13c8-43c1-8b3f-44740750b5a0, target_path: /s3/cache/test.log }
 ```
 
-可用 `job_id` 查询缓存任务状态：
+客户端启用 Transfer 后，自动缓存会创建 Transfer Job。可使用 Job ID 查询状态：
 
 ```plain
-cv load-status 7c00853f-13c8-43c1-8b3f-44740750b5a0
+cv transfer status 7c00853f-13c8-43c1-8b3f-44740750b5a0
 ```
+
+`load-status` 仍是兼容命令。未启用 Transfer 的客户端仍查询旧 Master Job 路径。
 
 ### 9.2 主动缓存
 
-可以使用 `load` 命令主动加载 UFS 数据到 Curvine，示例如下：
+先挂载 UFS，再通过它在 Curvine 中的路径主动加载：
 
 ```plain
-cv load s3://bucket/cache/test.log
+cv load /data/cache/test.log --watch
 ```
 
 自动缓存与主动缓存可同时使用；主动缓存可缩短该文件首次读取的等待时间。
 
-启用 Transfer 后，可使用 `cv transfer list` 和 `cv transfer status <job_id>` 执行任务级运维；`cv load-status` 仍是兼容的状态查询命令。
+客户端启用 Transfer 后，同一个 `cv load` 会自动提交 Transfer Job。服务部署和客户端
+路由见 [Transfer 服务](../../2-Deploy/3-Transfer-Service/0-Overview.md)。可使用
+`cv transfer list` 和 `cv transfer status <job_id>` 执行任务级运维。
 
 :::tip
 加载数据前，须先将 UFS 挂载到 Curvine（`cv mount`）。

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/3-User-Manuals/2-Operations/02-cli.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/3-User-Manuals/2-Operations/02-cli.md
@@ -39,7 +39,7 @@ Commands:
 
 | 全局参数 | 说明 |
 |----------|------|
-| `-c, --conf <PATH>` | 仅覆盖本次调用的集群配置文件。未指定时 CLI 使用正常配置路径或 `CURVINE_CONF_FILE`。 |
+| `--conf <PATH>` | 仅覆盖本次调用的集群配置文件。未指定时 CLI 使用正常配置路径或 `CURVINE_CONF_FILE`。 |
 | `--master-addrs <ADDRS>` | 直接覆盖客户端配置里的 Master 地址列表，例如 `m1:8995,m2:8995`。 |
 
 :::tip
@@ -281,35 +281,38 @@ cv umount /bucket/datasets
 
 ---
 
-### 6. `load`：提交加载任务
+### 6. `load`：提交 Load 任务
 
-**用法：** `cv load [OPTIONS] <PATH>`
+**用法：** `cv load [OPTIONS] <SOURCE_PATH> [TARGET_PATH]`
 
 | 选项 / 参数 | 说明 |
 |-------------|------|
-| `<PATH>` | 要加载的源路径。通常是已经建立挂载关系的 UFS 路径。 |
+| `<SOURCE_PATH>` | UFS 源 URI，或已有 mount 下的 Curvine 路径。 |
+| `[TARGET_PATH]` | 可选 Curvine 目标路径。已挂载源路径会自动推导目标。 |
 | `-w, --watch` | 提交后立即持续观察任务状态。 |
-| `--conf <PATH>` | 可选的单次配置覆盖；日常使用不需要。 |
+| `--no-overwrite` | 目标已经存在时失败，不覆盖目标。 |
 
 示例：
 
 ```bash
-cv load s3://bucket/datasets/train/part-0001.parquet
-cv load s3://bucket/datasets/train/part-0001.parquet --watch
+cv load /datasets/train/part-0001.parquet --watch
+cv load s3://bucket/datasets/train/part-0001.parquet /datasets/train/part-0001.parquet --no-overwrite --watch
 ```
 
-成功时命令会输出 `job_id` 和 `target_path`，后续可交给 `load-status` 或 `cancel-load`。
+启用 Transfer 后，`load` 会提交 Transfer Job；否则使用旧 Master Job 路径。两种模式
+下命令都会输出 Job ID 和目标路径。
 
 #### Transfer 路由
 
 启用独立 Transfer 后，命令行不变：
 
-| 集群配置 | `cv load` / `cv export` 路由 |
+| 客户端配置 | `cv load` / `cv export` 路由 |
 | --- | --- |
 | `[transfer] enabled = false` | 为兼容已有集群，调用旧 Master Load API。 |
 | `[transfer] enabled = true` | CLI 直接调用 Transfer 服务 RPC。 |
 
-Master 不会将旧请求代理到 Transfer。切换时，必须保证 CLI 与集群使用相同的 `[transfer]` 配置；过期的 CLI 配置会被拒绝，避免产生第二个任务所有者。
+Transfer 服务和客户端都需要配置 Transfer。按客户端切换时无需修改 Master 和 Worker
+配置；`transfer.enabled = false` 的客户端会继续调用旧 Master API。
 
 ---
 
@@ -377,6 +380,9 @@ cv cancel-load <job_id>
 ### 10. `transfer`：运维 Transfer 任务
 
 `cv transfer` 仅在 `[transfer] enabled = true` 时可用。它用于列举、查看、重试和分页查询 Transfer 任务；日常提交仍使用 `cv load` 或 `cv export`。
+
+该命令要求客户端配置可访问的 Transfer endpoint。服务部署见
+[Transfer 服务](../../2-Deploy/3-Transfer-Service/0-Overview.md)。
 
 | 命令 | 说明 |
 | --- | --- |

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/5-Architecture/02-opendal-integration.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/5-Architecture/02-opendal-integration.md
@@ -67,31 +67,22 @@ bin/cv mount hdfs://namenode:9000/data /mnt/hdfs
 
 ### Load 功能 - 加载外部数据
 
-`load` 功能允许直接从外部存储加载数据到 Curvine 中，支持单文件或批量加载。
-
-#### 单文件加载示例
-
-```bash
-# 从 S3 加载单个文件
-bin/cv load s3://flink/user/simple_test.txt \
-    -c s3.endpoint_url=http://s3v2.dg-access-test.wanyol.com \
-    -c s3.region_name=cn-south-1 \
-    -c s3.credentials.access=*** \
-    -c s3.credentials.secret=***
-```
-
-#### 批量加载示例
+外部路径只需在挂载时配置一次，包括 UFS 凭据和 endpoint；随后通过挂载后的 Curvine
+路径加载。这样无需在每次 Load 命令中传递凭据，源路径和目标路径的映射也更明确。
 
 ```bash
-# 从 OSS 加载整个目录
-bin/cv load oss://my-bucket/datasets/ \
-    -c oss.endpoint_url=https://oss-cn-hangzhou.aliyuncs.com \
-    -c oss.credentials.access_key_id=*** \
-    -c oss.credentials.access_key_secret=***
+# S3 已挂载到 /mnt/s3。
+cv load /mnt/s3/simple_test.txt --watch
 
-# 从 HDFS 加载
-bin/cv load hdfs://namenode:9000/data/logs/
+# 加载已挂载的 OSS 目录。
+cv load /mnt/oss/datasets --watch
+
+# 加载已挂载的 HDFS 目录。
+cv load /mnt/hdfs/logs --watch
 ```
+
+客户端启用 Transfer 后，同一个 `cv load` 会提交独立的 Transfer Job。服务和客户端配置
+见 [Transfer 服务部署](../2-Deploy/3-Transfer-Service/0-Overview.md)。
 
 ### 配置参数说明
 
@@ -155,4 +146,3 @@ export LD_LIBRARY_PATH=/opt/hadoop/lib/native:$LD_LIBRARY_PATH
 ```
 
 **注意**：请确保所有 Worker 节点都配置了正确的 Java 和 Hadoop 环境变量，否则 HDFS 挂载和加载操作将会失败。
-


### PR DESCRIPTION
# Summary

Adds a dedicated Transfer deployment section for the independent Load and Export service, and aligns the Load, cache, OpenDAL, and CLI guides with Transfer client routing.

# Issue Describe / Design

Related to CurvineIO/curvine#1040.

The documentation separates core cluster installation from the optional Transfer service. SQLite is documented as a single-instance deployment with persistent storage; MySQL is required before running multiple Transfer instances. Master and Worker configuration remain unchanged during client-side rollout.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `docs/2-Deploy` | Adds deployment overview plus bare-metal and Kubernetes Transfer guides. | New documentation only. |
| Transfer configuration reference | Documents supported `[transfer]` fields and defaults. | New documentation only. |
| Load, cache, CLI, and OpenDAL guides | Documents Transfer routing and `cv transfer` operations. | Clarifies existing behavior and compatibility. |
| `i18n/zh-cn` | Adds matching Chinese documentation. | New documentation only. |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `npm run build` | PASS | Built English and Chinese documentation sites. |
| `git diff --check` | PASS | No whitespace errors in the change. |

# Dependencies

- Related PRs: None
- Related issues: CurvineIO/curvine#1040
- Blocks / blocked by: None