### PR TITLE
docs: add Slack link to footer

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -143,6 +143,10 @@ const config: Config = {
               href: 'https://discord.com/invite/xfxMQKv3',
             },
             {
+              label: 'Slack',
+              href: 'https://join.slack.com/t/curvineio/shared_invite/zt-4673r43cn-prajma_q5ZI3BUxuaY5kiQ',
+            },
+            {
               label: 'X',
               href: 'https://x.com/szbr8896',
             },

--- a/i18n/en/docusaurus-theme-classic/footer.json
+++ b/i18n/en/docusaurus-theme-classic/footer.json
@@ -19,6 +19,10 @@
     "message": "Discord",
     "description": "The label of footer link with label=Discord linking to https://discord.com/invite/xfxMQKv3"
   },
+  "link.item.label.Slack": {
+    "message": "Slack",
+    "description": "The label of footer link with label=Slack linking to https://join.slack.com/t/curvineio/shared_invite/zt-4673r43cn-prajma_q5ZI3BUxuaY5kiQ"
+  },
   "link.item.label.X": {
     "message": "X",
     "description": "The label of footer link with label=X linking to https://x.com/szbr8896"

--- a/i18n/zh-cn/docusaurus-theme-classic/footer.json
+++ b/i18n/zh-cn/docusaurus-theme-classic/footer.json
@@ -19,6 +19,10 @@
     "message": "Discord",
     "description": "The label of footer link with label=Discord linking to https://discord.com/invite/xfxMQKv3"
   },
+  "link.item.label.Slack": {
+    "message": "Slack",
+    "description": "The label of footer link with label=Slack linking to https://join.slack.com/t/curvineio/shared_invite/zt-4673r43cn-prajma_q5ZI3BUxuaY5kiQ"
+  },
   "link.item.label.X": {
     "message": "X",
     "description": "The label of footer link with label=X linking to https://x.com/szbr8896"


### PR DESCRIPTION
## Summary
- Add the Slack invite link to the Docusaurus footer Community section.
- Add matching footer translation entries for en and zh-cn.

## Testing
- npm run build (passes; existing warnings remain for blog metadata/truncation and the #ref-spdk-iops broken anchor).