### PR TITLE
docs(ops): add version management, compatibility matrix and release notes pages

### DIFF
--- a/docs/3-User-Manuals/2-Operations/02-cli.md
+++ b/docs/3-User-Manuals/2-Operations/02-cli.md
@@ -95,6 +95,7 @@ In the current implementation, `cv report capacity <WORKER_ADDRESS>` matches by 
 | Option | Description |
 |--------|-------------|
 | `-l, --list` | List live and lost workers. |
+| `--versions` | Show release-version distribution across all live workers. |
 | `--add-decommission <NODES>...` | Add one or more workers to the decommission list. |
 | `--remove-decommission <NODES>...` | Remove one or more workers from the decommission list. |
 
@@ -107,10 +108,28 @@ Examples:
 
 ```bash
 cv node -l
+cv node --versions
 cv node --add-decommission host1:8997 host2:8997
 cv node --add-decommission host1:8997,host2:8997
 cv node --remove-decommission host1:8997
 ```
+
+`cv node --versions` prints the release-version distribution across live
+workers, preferring the structured `component_info.release_version` reported on
+heartbeat and falling back to the legacy `software_version` string:
+
+```text
+Version Distribution:
+----------------------------------------
+  0.4.0-alpha              : 3 worker(s)
+  0.4.0-beta               : 5 worker(s)
+  legacy (0.3.0-test)      : 1 worker(s)
+----------------------------------------
+  total                    : 9 worker(s)
+```
+
+See [Version Management and Compatibility](04-version-management.md) for the
+meaning of these versions and how the master evaluates mixed-version peers.
 
 :::note
 The current implementation strips `hostname:port` down to `hostname` before calling the decommission API. The port is mainly for readability and consistent input format.
@@ -427,6 +446,17 @@ cv version
 ```
 
 The current implementation prints `curvine-cli <version>` together with commit / branch information.
+
+Every binary also accepts the global `--version-json` flag to print its full
+structured version (component, release version, git provenance, protocol
+version, capabilities) as JSON — see
+[Version Management and Compatibility](04-version-management.md):
+
+```bash
+cv --version-json
+curvine-master --version-json
+curvine-worker --version-json
+```
 
 ---
 

--- a/docs/3-User-Manuals/2-Operations/03-monitoring.md
+++ b/docs/3-User-Manuals/2-Operations/03-monitoring.md
@@ -31,6 +31,24 @@ Master, worker, FUSE, and S3 gateway nodes expose monitoring metrics through HTT
 | replication_failure_count | Total cumulative replication failures |
 | operation_duration | Operation duration (classified by type, excluding heartbeats) |
 
+### Compatibility Metrics
+
+The master evaluates every worker heartbeat and client handshake against its
+compatibility contract and exposes the results as metrics (see
+[Version Management and Compatibility](04-version-management.md)):
+
+| Metric Name | Type | Labels | Description |
+|-------------|------|--------|-------------|
+| compat_worker_verdict | Gauge | `worker_id`, `verdict` | 1 for the current compatibility verdict of each worker |
+| compat_client_verdict | Gauge | `client_addr`, `verdict` | 1 for the current compatibility verdict of each client |
+| compat_enforce_rejected_total | Counter | `component`, `verdict` | Total number of enforce-mode compatibility rejections |
+
+The `verdict` label takes one of: `compatible`, `missing_info`, `blocked`,
+`protocol_mismatch`, `version_too_old`, `version_unknown`. Alert on
+`compat_worker_verdict` / `compat_client_verdict` with a non-`compatible`
+verdict to surface mixed-version clusters, and on `compat_enforce_rejected_total`
+increases to catch upgrade conflicts early.
+
 ## Journal Node Metrics
 
 | Metric Name | Description |

--- a/docs/3-User-Manuals/2-Operations/04-version-management.md
+++ b/docs/3-User-Manuals/2-Operations/04-version-management.md
@@ -1,0 +1,190 @@
+# Version Management and Compatibility
+
+This chapter describes how Curvine components version themselves and how to
+operate a cluster whose components may run different versions. Since 0.4.x
+every binary emits structured version metadata, servers advertise a
+compatibility contract, and the master evaluates peers with a lenient
+`diagnose`-by-default policy.
+
+## Version Schema
+
+All Curvine components use the same version schema:
+
+```
+<major>.<minor>.<patch>[-<pre-release>][+<build>]
+```
+
+Examples: `0.4.0`, `0.4.0-alpha`, `0.5.0-rc.1+build.1234`
+
+Pre-release versions sort before the corresponding release version, following
+SemVer precedence: `0.4.0-alpha < 0.4.0-beta < 0.4.0`.
+
+## Protocol Version
+
+The **protocol version** is a monotonic integer that governs wire-level
+compatibility between components. It is **not** the same as the release
+version.
+
+| Protocol Version | Curvine Release | Notes |
+|---|---|---|
+| 1 | 0.4.x | Initial structured protocol version |
+
+A component accepts a peer whose protocol version falls within
+`[min_protocol_version, protocol_version]` of the server.
+
+## Viewing Component Versions
+
+Every binary prints its structured version as JSON with `--version-json`:
+
+```bash
+cv --version-json
+curvine-master --version-json
+curvine-worker --version-json
+curvine-fuse --version-json
+```
+
+Example output:
+
+```json
+{
+  "component": "worker",
+  "release_version": "0.4.0-alpha",
+  "git_commit": "24c848719b5b4fea74519d91cbe462bb49761b36",
+  "git_tag": "v0.4.0-alpha",
+  "git_branch": "main",
+  "protocol_version": 1,
+  "min_protocol_version": 1,
+  "capabilities": ["transfer", "batch-write"]
+}
+```
+
+The fields are:
+
+- `component` — component name (`master`, `worker`, `client`, `fuse`, `cli`, `csi`).
+- `release_version` — Cargo/package version of the build.
+- `git_commit` / `git_tag` / `git_branch` — exact source provenance.
+- `protocol_version` / `min_protocol_version` — wire protocol bounds.
+- `capabilities` — feature-level negotiation tokens.
+
+## Worker Version Statistics
+
+The CLI can summarize the release-version distribution across all live
+workers. This is the fastest way to see whether a cluster is running a
+homogeneous set of versions or a mix of old and new workers:
+
+```bash
+cv node --versions
+```
+
+Example output:
+
+```text
+Version Distribution:
+----------------------------------------
+  0.4.0-alpha              : 3 worker(s)
+  0.4.0-beta               : 5 worker(s)
+  legacy (0.3.0-test)      : 1 worker(s)
+----------------------------------------
+  total                    : 9 worker(s)
+```
+
+Workers that report structured `component_info` count under their
+`release_version`; older workers that only report the legacy
+`software_version` string are counted as `legacy (<version>)`. Workers with no
+usable version data at all are grouped under `legacy (no version)`.
+
+## Compatibility Between Components
+
+The master evaluates every worker heartbeat and client handshake against its
+own compatibility contract. The default behavior is **lenient**: without
+explicit configuration the master records a warning and allows the request, so
+old components are never rejected just because they predate the structured
+version protocol.
+
+### Master ↔ Worker
+
+| Master | Worker | Protocol | Default Behavior |
+|---|---|---|---|
+| 0.4.x | 0.4.x | 1 | ✅ Compatible |
+| 0.4.x | 0.3.x (legacy, no `component_info`) | n/a | ⚠️ Warning in `diagnose`; rejected only in `enforce` |
+| 0.4.x | < `min_worker_version` | n/a | ⚠️ Warning in `diagnose`; rejected only in `enforce` |
+
+### Master ↔ Client (including FUSE / CLI / CSI)
+
+| Master | Client | Protocol | Default Behavior |
+|---|---|---|---|
+| 0.4.x | 0.4.x | 1 | ✅ Compatible |
+| 0.4.x | 0.3.x (legacy) | n/a | ⚠️ Warning in `diagnose`; rejected only in `enforce` |
+
+### Worker ↔ Client (data plane)
+
+| Worker | Client | Protocol | Default Behavior |
+|---|---|---|---|
+| 0.4.x | 0.4.x | 1 | ✅ Compatible |
+| 0.4.x | 0.3.x (legacy) | n/a | ⚠️ Warning in `diagnose`; rejected only in `enforce` |
+
+## Enforcement Policy
+
+The compatibility policy is configured in the master configuration file:
+
+```toml
+[master.compatibility]
+# "diagnose" (default): warn on incompatibility, allow the request.
+# "enforce": reject incompatible requests with an explicit error.
+mode = "diagnose"
+
+# Minimum worker release version (empty = not enforced).
+min_worker_version = "0.2.0"
+
+# Minimum client release version (empty = not enforced).
+min_client_version = "0.1.5"
+
+# Release versions explicitly rejected regardless of mode (emergency backstop).
+blocked_versions = ["0.2.5"]
+```
+
+- **`mode = "diagnose"` (default):** incompatible peers are allowed, and the
+  master logs a warning describing the peer, its version, and the expected
+  bound. This is the safe default and never breaks an existing mixed-version
+  cluster.
+- **`mode = "enforce"`:** incompatible peers are rejected with an explicit
+  error that includes the actual peer version and the upgrade suggestion.
+- **`blocked_versions`:** release versions listed here are **always rejected**
+  regardless of the mode. This is an emergency backstop for known-bad builds
+  (see the known-incompatible list on the release notes page).
+
+## Capabilities
+
+Beyond versions, features are negotiated through capability tokens that each
+component advertises in its `ComponentVersion`. A feature is enabled only when
+**both** peers declare it, so a capability introduced in a newer release is
+silently disabled until the whole data path upgrades.
+
+| Capability | Description | Introduced In |
+|---|---|---|
+| `transfer` | Data transfer between workers | 0.4.0 |
+| `batch-write` | Batch write optimization | 0.4.0 |
+| `short-circuit` | Short-circuit read (client → worker direct) | 0.4.0 |
+
+## Observability
+
+The master exposes compatibility metrics on the Prometheus endpoint
+(`http://<master>:9000/metrics`). See the [Monitoring Metrics](03-monitoring.md)
+page for the full metric table.
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `compat_worker_verdict` | Gauge | `worker_id`, `verdict` | 1 for the current compatibility verdict of each worker |
+| `compat_client_verdict` | Gauge | `client_addr`, `verdict` | 1 for the current compatibility verdict of each client |
+| `compat_enforce_rejected_total` | Counter | `component`, `verdict` | Total number of enforce-mode compatibility rejections |
+
+`verdict` takes one of: `compatible`, `missing_info`, `blocked`,
+`protocol_mismatch`, `version_too_old`, `version_unknown`.
+
+## Release Notes and Known Incompatibilities
+
+Each release ships release notes that repeat the compatibility table for that
+specific version. The known-incompatible list and the release notes template
+are maintained in the release notes page; keep the compatibility table there
+in sync whenever a version is added to `blocked_versions` or a new protocol
+version is introduced.

--- a/docs/3-User-Manuals/2-Operations/05-release-notes.md
+++ b/docs/3-User-Manuals/2-Operations/05-release-notes.md
@@ -1,0 +1,109 @@
+# Release Notes and Known Incompatible Versions
+
+This page compiles the release notes template used for each Curvine release and
+the list of release versions known to be incompatible with other Curvine
+components. Keep this page in sync whenever a version is added to
+`master.compatibility.blocked_versions` or a new protocol version is
+introduced.
+
+## Release Notes Template
+
+Copy the template below, fill in the version and date, and ship it with the
+release announcement. The **Compatibility** table must match the
+[Compatibility Matrix](04-version-management.md) for that version.
+
+```markdown
+## Curvine v<VERSION> — <RELEASE_DATE>
+
+### Highlights
+
+_Brief description of the most important changes in this release (2-3 sentences)._
+
+### Upgrade Notes
+
+- **Compatibility:** Review the Compatibility Matrix before upgrading. The
+  default mode is `diagnose` (lenient), so old components are not rejected
+  without explicit configuration.
+- **Breaking changes:** _List any breaking changes, config migration steps, or
+  deprecations here._
+- **Minimum versions:** _List updated minimum version requirements here._
+
+### New Features
+
+- _Feature 1: short description. ([#NNN](https://github.com/CurvineIO/curvine/pull/NNN))_
+- _Feature 2: short description. ([#NNN](https://github.com/CurvineIO/curvine/pull/NNN))_
+
+### Bug Fixes
+
+- _Bug fix 1: short description. ([#NNN](https://github.com/CurvineIO/curvine/pull/NNN))_
+- _Bug fix 2: short description. ([#NNN](https://github.com/CurvineIO/curvine/pull/NNN))_
+
+### Compatibility
+
+| Component | Min Version | Max Version | Protocol |
+|---|---|---|---|
+| master | <MIN> | <MAX> | <PROTO> |
+| worker | <MIN> | <MAX> | <PROTO> |
+| client | <MIN> | <MAX> | <PROTO> |
+| FUSE | <MIN> | <MAX> | <PROTO> |
+| CLI | <MIN> | <MAX> | <PROTO> |
+| CSI | <MIN> | <MAX> | <PROTO> |
+
+### Known Issues
+
+- _List any known issues, version-specific incompatibilities, or limitations._
+
+### Assets
+
+- **Binary (Rocky Linux 9, x86_64):** `curvine-<VERSION>-linux-amd64.tar.gz`
+- **Docker images:** `ghcr.io/curvineio/curvine:<VERSION>`
+- **Helm chart:** `curvine-<VERSION>.tgz`
+
+### Release Process
+
+1. Validate the release tag:
+   `bash build/validate-release-version.sh v<VERSION>`
+2. Build: `BUILD_VERSION=<VERSION> make dist`
+3. Verify injected artifact versions.
+4. Push the tag to trigger the release workflow.
+
+---
+
+**Full Changelog:** https://github.com/CurvineIO/curvine/compare/v<PREVIOUS>...v<VERSION>
+```
+
+## Known Incompatible Versions
+
+Release versions are added to this list when they have critical bugs or
+protocol-level incompatibilities that make them unsafe in a mixed-version
+cluster. The corresponding `blocked_versions` entry in the master
+`compatibility` section is the operational enforcement of these entries:
+blocked versions are **always rejected regardless of mode** (emergency
+backstop).
+
+| Version | Component | Reason | Introduced In | Resolution |
+|---|---|---|---|---|
+| 0.2.5 | worker | Critical data corruption bug in batch-write path | 0.2.5 | Upgrade to 0.2.6+ or 0.3.0+ |
+
+### Version-Specific Incompatibilities
+
+**0.3.x legacy workers / clients with 0.4.x master.** Workers and clients
+running 0.3.x (or earlier) do not send structured `component_info`. The master
+detects them as legacy peers: allowed with a warning in `diagnose` mode
+(default), rejected only in `enforce` mode. No data loss or protocol error
+occurs; the master simply cannot verify their protocol version, release
+version, or capabilities.
+
+**Pre-release vs release bounds.** Pre-release versions sort before the
+corresponding release version (`0.4.0-alpha < 0.4.0`). If
+`min_worker_version = "0.4.0"` is configured, a pre-release worker is rejected
+because it sorts below the bound. To allow pre-releases, lower the minimum
+bound accordingly.
+
+## Reporting a New Incompatibility
+
+1. Open a GitHub issue with the **compatibility** label.
+2. Include: master version, worker/client version, protocol version of each
+   component, the full compatibility error or warning, and reproduction steps.
+3. The Curvine team evaluates and either adds the version to `blocked_versions`
+   or documents the incompatibility on this page.

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/3-User-Manuals/2-Operations/02-cli.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/3-User-Manuals/2-Operations/02-cli.md
@@ -92,6 +92,7 @@ cv report available
 | 选项 | 说明 |
 |------|------|
 | `-l, --list` | 列出 live / lost worker。 |
+| `--versions` | 展示所有在线 worker 的版本分布。 |
 | `--add-decommission <NODES>...` | 将一个或多个 worker 加入退役列表。 |
 | `--remove-decommission <NODES>...` | 将一个或多个 worker 从退役列表移除。 |
 
@@ -104,10 +105,26 @@ cv report available
 
 ```bash
 cv node -l
+cv node --versions
 cv node --add-decommission host1:8997 host2:8997
 cv node --add-decommission host1:8997,host2:8997
 cv node --remove-decommission host1:8997
 ```
+
+`cv node --versions` 打印在线 worker 的版本分布，优先使用心跳上报的结构化
+`component_info.release_version`，回退到旧的 `software_version` 字符串：
+
+```text
+Version Distribution:
+----------------------------------------
+  0.4.0-alpha              : 3 worker(s)
+  0.4.0-beta               : 5 worker(s)
+  legacy (0.3.0-test)      : 1 worker(s)
+----------------------------------------
+  total                    : 9 worker(s)
+```
+
+这些版本的含义以及 master 如何评估混合版本 peer，请参阅[版本管理与兼容性](04-version-management.md)。
 
 :::note
 当前实现会在退役 API 调用前把 `hostname:port` 截断为 `hostname`。也就是说，端口主要用于人类可读和输入格式统一。
@@ -416,6 +433,17 @@ cv version
 ```
 
 当前实现会输出 `curvine-cli <version>`，并带上 commit / branch 信息。
+
+所有二进制还支持全局 `--version-json` 参数，以 JSON 形式输出完整结构化版本
+（组件名、发布版本、git 来源、协议版本、能力）：
+
+```bash
+cv --version-json
+curvine-master --version-json
+curvine-worker --version-json
+```
+
+详细说明请参阅[版本管理与兼容性](04-version-management.md)。
 
 ---
 

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/3-User-Manuals/2-Operations/03-monitoring.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/3-User-Manuals/2-Operations/03-monitoring.md
@@ -30,6 +30,23 @@ master,worker,fuse,s3 gateway会通过http接口暴露监控指标，可以在pr
 | replication_failure_count | 累计复制失败的总次数 |
 | operation_duration | 操作耗时（按类型分类，不包括心跳） |
 
+### 兼容性指标
+
+master 会对每个 worker 心跳和客户端握手执行兼容性评估，并将结果暴露为指标
+（详见[版本管理与兼容性](04-version-management.md)）：
+
+| 指标名称 | 类型 | 标签 | 描述 |
+|---------|------|------|------|
+| compat_worker_verdict | Gauge | `worker_id`、`verdict` | 每个 worker 当前兼容性结论，为 1 |
+| compat_client_verdict | Gauge | `client_addr`、`verdict` | 每个 client 当前兼容性结论，为 1 |
+| compat_enforce_rejected_total | Counter | `component`、`verdict` | enforce 模式下累计拒绝次数 |
+
+`verdict` 标签取值：`compatible`、`missing_info`、`blocked`、
+`protocol_mismatch`、`version_too_old`、`version_unknown`。建议对
+`compat_worker_verdict` / `compat_client_verdict` 中非 `compatible` 的结论设置告警，
+以发现混合版本集群；对 `compat_enforce_rejected_total` 的增长设置告警，
+及早发现升级冲突。
+
 ## Journal Node 指标
 
 | 指标名称 | 描述 |

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/3-User-Manuals/2-Operations/04-version-management.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/3-User-Manuals/2-Operations/04-version-management.md
@@ -1,0 +1,157 @@
+# 版本管理与兼容性
+
+本章介绍 Curvine 各组件的版本自描述机制，以及如何运维一个组件版本不完全一致的集群。自 0.4.x 起，每个二进制都会输出结构化版本信息，服务端会广播兼容性契约，master 以默认 `diagnose`（宽松）策略对 peer 进行评估。
+
+## 版本格式
+
+所有 Curvine 组件使用统一的版本格式：
+
+```
+<major>.<minor>.<patch>[-<预发布>][+<构建号>]
+```
+
+示例：`0.4.0`、`0.4.0-alpha`、`0.5.0-rc.1+build.1234`
+
+预发布版本按 SemVer 规则排在正式版本之前：`0.4.0-alpha < 0.4.0-beta < 0.4.0`。
+
+## 协议版本
+
+**协议版本**是用于约束组件之间线上兼容性的单调递增整数，**不等同于**发布版本。
+
+| 协议版本 | Curvine 发布版本 | 说明 |
+|---|---|---|
+| 1 | 0.4.x | 初始结构化协议版本 |
+
+组件只接受协议版本落在 `[min_protocol_version, protocol_version]` 范围内的 peer。
+
+## 查看组件版本
+
+所有二进制都支持 `--version-json` 输出结构化版本 JSON：
+
+```bash
+cv --version-json
+curvine-master --version-json
+curvine-worker --version-json
+curvine-fuse --version-json
+```
+
+输出示例：
+
+```json
+{
+  "component": "worker",
+  "release_version": "0.4.0-alpha",
+  "git_commit": "24c848719b5b4fea74519d91cbe462bb49761b36",
+  "git_tag": "v0.4.0-alpha",
+  "git_branch": "main",
+  "protocol_version": 1,
+  "min_protocol_version": 1,
+  "capabilities": ["transfer", "batch-write"]
+}
+```
+
+字段含义：
+
+- `component` — 组件名称（`master`、`worker`、`client`、`fuse`、`cli`、`csi`）。
+- `release_version` — Cargo/包版本。
+- `git_commit` / `git_tag` / `git_branch` — 精确的源码来源信息。
+- `protocol_version` / `min_protocol_version` — 线上协议范围。
+- `capabilities` — 特性级协商令牌。
+
+## 查看 Worker 版本统计
+
+CLI 可以汇总所有在线 worker 的版本分布，快速判断集群是运行同构版本还是包含新旧混合版本：
+
+```bash
+cv node --versions
+```
+
+输出示例：
+
+```text
+Version Distribution:
+----------------------------------------
+  0.4.0-alpha              : 3 worker(s)
+  0.4.0-beta               : 5 worker(s)
+  legacy (0.3.0-test)      : 1 worker(s)
+----------------------------------------
+  total                    : 9 worker(s)
+```
+
+上报结构化 `component_info` 的 worker 按其 `release_version` 统计；仅上报旧版 `software_version` 字符串的 worker 按 `legacy (<版本>)` 统计；完全没有版本数据的 worker 归入 `legacy (no version)`。
+
+## 组件间兼容性
+
+master 会对每个 worker 心跳和客户端握手执行兼容性评估。默认行为是**宽松**的：在未显式配置的情况下，master 记录警告并允许请求，因此旧组件不会仅仅因为它们不包含结构化版本协议而被拒绝。
+
+### Master ↔ Worker
+
+| Master | Worker | 协议 | 默认行为 |
+|---|---|---|---|
+| 0.4.x | 0.4.x | 1 | ✅ 兼容 |
+| 0.4.x | 0.3.x（旧版，无 `component_info`） | 无 | ⚠️ `diagnose` 下告警；仅 `enforce` 下拒绝 |
+| 0.4.x | 低于 `min_worker_version` | 无 | ⚠️ `diagnose` 下告警；仅 `enforce` 下拒绝 |
+
+### Master ↔ Client（含 FUSE / CLI / CSI）
+
+| Master | Client | 协议 | 默认行为 |
+|---|---|---|---|
+| 0.4.x | 0.4.x | 1 | ✅ 兼容 |
+| 0.4.x | 0.3.x（旧版） | 无 | ⚠️ `diagnose` 下告警；仅 `enforce` 下拒绝 |
+
+### Worker ↔ Client（数据面）
+
+| Worker | Client | 协议 | 默认行为 |
+|---|---|---|---|
+| 0.4.x | 0.4.x | 1 | ✅ 兼容 |
+| 0.4.x | 0.3.x（旧版） | 无 | ⚠️ `diagnose` 下告警；仅 `enforce` 下拒绝 |
+
+## 强制策略
+
+兼容性策略在 master 配置文件中配置：
+
+```toml
+[master.compatibility]
+# "diagnose"（默认）：不兼容仅告警，允许请求。
+# "enforce"：不兼容直接拒绝并返回明确错误。
+mode = "diagnose"
+
+# worker 最低发布版本（留空表示不强制）。
+min_worker_version = "0.2.0"
+
+# client 最低发布版本（留空表示不强制）。
+min_client_version = "0.1.5"
+
+# 无论何种模式都显式拒绝的版本（紧急兜底）。
+blocked_versions = ["0.2.5"]
+```
+
+- **`mode = "diagnose"`（默认）：** 不兼容的 peer 被允许，master 记录告警，内容包括 peer、其版本和期望的边界。这是安全默认值，不会破坏已有的混合版本集群。
+- **`mode = "enforce"`：** 不兼容的 peer 被拒绝，错误信息包含实际 peer 版本和升级建议。
+- **`blocked_versions`：** 列出的版本无论模式如何都**总是被拒绝**。这是针对已知问题版本的紧急兜底手段（见发布说明页的已知不兼容清单）。
+
+## 能力（Capabilities）
+
+除版本外，功能还通过能力令牌协商：每个组件在其 `ComponentVersion` 中声明能力，只有**双方**都声明某能力时该特性才启用。因此在新发布中引入的能力会静默禁用，直到整个数据链路都升级。
+
+| 能力 | 说明 | 引入版本 |
+|---|---|---|
+| `transfer` | Worker 间数据传输 | 0.4.0 |
+| `batch-write` | 批量写入优化 | 0.4.0 |
+| `short-circuit` | 短路读（客户端 → Worker 直连） | 0.4.0 |
+
+## 可观测性
+
+master 在 Prometheus 端点（`http://<master>:9000/metrics`）暴露兼容性指标，完整指标表见[监控指标](03-monitoring.md)。
+
+| 指标 | 类型 | 标签 | 说明 |
+|---|---|---|---|
+| `compat_worker_verdict` | Gauge | `worker_id`、`verdict` | 每个 worker 当前兼容性结论，为 1 |
+| `compat_client_verdict` | Gauge | `client_addr`、`verdict` | 每个 client 当前兼容性结论，为 1 |
+| `compat_enforce_rejected_total` | Counter | `component`、`verdict` | enforce 模式下累计拒绝次数 |
+
+`verdict` 取值：`compatible`、`missing_info`、`blocked`、`protocol_mismatch`、`version_too_old`、`version_unknown`。
+
+## 发布说明与已知不兼容
+
+每个发布都会附带包含该版本兼容性对照表的发布说明。已知不兼容清单与发布说明模板在发布说明页维护；每当有版本加入 `blocked_versions` 或引入新的协议版本时，请同步更新该页的兼容性对照表。

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/3-User-Manuals/2-Operations/05-release-notes.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/3-User-Manuals/2-Operations/05-release-notes.md
@@ -1,0 +1,85 @@
+# 发布说明与已知不兼容版本
+
+本页汇总 Curvine 每次发布使用的发布说明模板，以及已知与其他 Curvine 组件不兼容的发布版本清单。每当有版本加入 `master.compatibility.blocked_versions` 或引入新的协议版本时，请同步更新本页。
+
+## 发布说明模板
+
+复制下面的模板，填入版本号和日期，随发布公告一起发布。**兼容性**表必须与[版本管理与兼容性](04-version-management.md)中该版本的兼容矩阵一致。
+
+```markdown
+## Curvine v<VERSION> — <RELEASE_DATE>
+
+### Highlights
+
+_简要描述本次发布最重要的变更（2-3 句）。_
+
+### Upgrade Notes
+
+- **兼容性：** 升级前请阅读版本管理与兼容性。默认模式为 `diagnose`（宽松），
+  没有显式配置时旧组件不会被拒绝。
+- **破坏性变更：** _列出破坏性变更、配置迁移步骤或弃用项。_
+- **最低版本：** _列出更新后的最低版本要求。_
+
+### New Features
+
+- _功能 1：简短描述。([#NNN](https://github.com/CurvineIO/curvine/pull/NNN))_
+- _功能 2：简短描述。([#NNN](https://github.com/CurvineIO/curvine/pull/NNN))_
+
+### Bug Fixes
+
+- _修复 1：简短描述。([#NNN](https://github.com/CurvineIO/curvine/pull/NNN))_
+- _修复 2：简短描述。([#NNN](https://github.com/CurvineIO/curvine/pull/NNN))_
+
+### Compatibility
+
+| 组件 | 最低版本 | 最高版本 | 协议 |
+|---|---|---|---|
+| master | <MIN> | <MAX> | <PROTO> |
+| worker | <MIN> | <MAX> | <PROTO> |
+| client | <MIN> | <MAX> | <PROTO> |
+| FUSE | <MIN> | <MAX> | <PROTO> |
+| CLI | <MIN> | <MAX> | <PROTO> |
+| CSI | <MIN> | <MAX> | <PROTO> |
+
+### Known Issues
+
+- _列出已知问题、版本特定的不兼容或限制。_
+
+### Assets
+
+- **二进制包（Rocky Linux 9, x86_64）：** `curvine-<VERSION>-linux-amd64.tar.gz`
+- **Docker 镜像：** `ghcr.io/curvineio/curvine:<VERSION>`
+- **Helm Chart：** `curvine-<VERSION>.tgz`
+
+### Release Process
+
+1. 校验发布标签：
+   `bash build/validate-release-version.sh v<VERSION>`
+2. 构建：`BUILD_VERSION=<VERSION> make dist`
+3. 校验注入的产物版本。
+4. 推送标签触发发布流水线。
+
+---
+
+**完整 Changelog：** https://github.com/CurvineIO/curvine/compare/v<PREVIOUS>...v<VERSION>
+```
+
+## 已知不兼容版本
+
+当某些版本存在关键缺陷或协议级不兼容，导致在混合版本集群中不安全时，会被加入本清单。master `compatibility` 配置中的 `blocked_versions` 是这些条目的运维强制执行手段：被列为 blocked 的版本**无论模式如何都总是被拒绝**（紧急兜底）。
+
+| 版本 | 组件 | 原因 | 引入版本 | 解决方案 |
+|---|---|---|---|---|
+| 0.2.5 | worker | batch-write 路径存在严重数据损坏缺陷 | 0.2.5 | 升级到 0.2.6+ 或 0.3.0+ |
+
+### 版本特定不兼容
+
+**0.3.x 旧版 worker / client 对接 0.4.x master。** 运行 0.3.x（或更早）的 worker 和 client 不上报结构化 `component_info`。master 将其识别为旧版 peer：`diagnose` 模式（默认）下允许并告警，仅在 `enforce` 模式下拒绝。不会发生数据丢失或协议错误，master 只是无法校验它们的协议版本、发布版本或能力。
+
+**预发布 vs 发布版本边界。** 预发布版本排在正式版本之前（`0.4.0-alpha < 0.4.0`）。如果配置了 `min_worker_version = "0.4.0"`，预发布 worker 会因低于边界而被拒绝。如需允许预发布版本，请相应调低最低版本。
+
+## 上报新的不兼容
+
+1. 打开 GitHub issue 并打上 **compatibility** 标签。
+2. 附带：master 版本、worker/client 版本、各组件的协议版本、完整的兼容性错误或告警，以及复现步骤。
+3. Curvine 团队评估后，要么将版本加入 `blocked_versions`，要么在本页记录该不兼容。


### PR DESCRIPTION
# Summary

Adds operational documentation for Curvine's version management and compatibility
features introduced in the 0.4.x series (structured component versions, worker
version reporting, diagnose/enforce compatibility policy).

# Issue Describe / Design

Related to https://github.com/CurvineIO/curvine/issues/1527 (component version
management) — sub-task T12 deliverables: compatibility matrix, known
incompatible versions, release notes template, CLI worker version statistics and
compatibility metrics documentation.

# Changes

| Module / File | Change | Impact on existing behavior |
| ------------- | ------ | --------------------------- |
| `docs/3-User-Manuals/2-Operations/04-version-management.md` + zh-cn | New page: version schema, protocol version, `--version-json`, `cv node --versions`, compatibility matrix, diagnose/enforce policy, capabilities, compatibility metrics | None (new page) |
| `docs/3-User-Manuals/2-Operations/05-release-notes.md` + zh-cn | New page: release notes template and known incompatible versions list | None (new page) |
| `docs/3-User-Manuals/2-Operations/02-cli.md` + zh-cn | Document `cv node --versions` and global `--version-json` | None (doc only) |
| `docs/3-User-Manuals/2-Operations/03-monitoring.md` + zh-cn | Document `compat_worker_verdict`, `compat_client_verdict`, `compat_enforce_rejected_total` metrics | None (doc only) |

# Test verified

| Test case | Result | Notes |
| --------- | ------ | ----- |
| `yarn build` (EN + zh-cn locales, broken-link check) | PASS | Docusaurus 3.8.0 |

# Dependencies

- Related PRs: None
- Related issues: https://github.com/CurvineIO/curvine/issues/1527
- Blocks / blocked by: None